### PR TITLE
Set default container option

### DIFF
--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGreengrassHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGreengrassHelper.java
@@ -314,7 +314,7 @@ public class BasicGreengrassHelper implements GreengrassHelper {
                 .functions(allFunctions);
 
         if (FunctionHelper.getDefaultFunctionIsolationMode().equals(FunctionIsolationMode.NO_CONTAINER)) {
-            log.info("Isolation mode set to NoContainer in function defaults file, setting default isolation mode for the group to NoContainer");
+            log.warn("Isolation mode set to NoContainer in function defaults file, setting default isolation mode for the group to NoContainer");
 
             functionDefinitionVersionBuilder.defaultConfig(
                     FunctionDefaultConfig.builder()

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGreengrassHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGreengrassHelper.java
@@ -316,7 +316,6 @@ public class BasicGreengrassHelper implements GreengrassHelper {
         //   - Functions that specify an isolation mode
         //   - Functions that don't specify an isolation mode
         //   - Functions that specify an isolation mode of NoContainer
-        //   - Functions that specify an isolation mode of GreengrassContainer
 
         Set<Function> functionsWithIsolationModeSpecified = allFunctions.stream()
                 .filter(function -> function.functionConfiguration().environment() != null)
@@ -330,10 +329,6 @@ public class BasicGreengrassHelper implements GreengrassHelper {
 
         Set<Function> functionsWithNoContainer = functionsWithIsolationModeSpecified.stream()
                 .filter(function -> function.functionConfiguration().environment().execution().isolationMode().equals(FunctionIsolationMode.NO_CONTAINER))
-                .collect(Collectors.toSet());
-
-        Set<Function> functionsWithGreengrassContainer = functionsWithIsolationModeSpecified.stream()
-                .filter(function -> function.functionConfiguration().environment().execution().isolationMode().equals(FunctionIsolationMode.GREENGRASS_CONTAINER))
                 .collect(Collectors.toSet());
 
         // Always scrub functions with the NoContainer isolation mode

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGreengrassHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGreengrassHelper.java
@@ -312,34 +312,13 @@ public class BasicGreengrassHelper implements GreengrassHelper {
                 .add(ggConstants.getGgIpDetectorFunction())
                 .build();
 
-        FunctionDefinitionVersion.Builder functionDefinitionVersionBuilder = FunctionDefinitionVersion.builder()
-                .functions(allFunctions);
-
-        /**
-         * This is a risky check of whether or not we should default to no container because if only one function
-         * requires no container and all of the other functions use the default values (particularly the GGIPDetector)
-         * then we'll switch to everything running outside of a container.
-         */
-        boolean allNoContainer = allFunctions.stream()
-                .map(Function::functionConfiguration)
-                .map(FunctionConfiguration::environment)
-                .map(FunctionConfigurationEnvironment::execution)
-                .map(FunctionExecutionConfig::isolationMode)
-                .allMatch(functionIsolationMode -> functionIsolationMode.equals(FunctionIsolationMode.NO_CONTAINER));
-
-        if (allNoContainer) {
-            log.info("All functions require NoContainer mode, setting default container mode for deployment to NoContainer");
-
-            functionDefinitionVersionBuilder.defaultConfig(
-                    FunctionDefaultConfig.builder()
-                            .execution(FunctionDefaultExecutionConfig.builder()
-                                    .isolationMode(FunctionIsolationMode.NO_CONTAINER).build())
-                            .build());
-        }
+        FunctionDefinitionVersion functionDefinitionVersion = FunctionDefinitionVersion.builder()
+                .functions(allFunctions)
+                .build();
 
         CreateFunctionDefinitionRequest createFunctionDefinitionRequest = CreateFunctionDefinitionRequest.builder()
                 .name(DEFAULT)
-                .initialVersion(functionDefinitionVersionBuilder.build())
+                .initialVersion(functionDefinitionVersion)
                 .build();
 
         CreateFunctionDefinitionResponse createFunctionDefinitionResponse = greengrassClient.createFunctionDefinition(createFunctionDefinitionRequest);

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGreengrassHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGreengrassHelper.java
@@ -36,8 +36,6 @@ public class BasicGreengrassHelper implements GreengrassHelper {
     GGConstants ggConstants;
     @Inject
     IdExtractor idExtractor;
-    @Inject
-    FunctionHelper functionHelper;
 
     @Inject
     public BasicGreengrassHelper() {
@@ -315,7 +313,7 @@ public class BasicGreengrassHelper implements GreengrassHelper {
         FunctionDefinitionVersion.Builder functionDefinitionVersionBuilder = FunctionDefinitionVersion.builder()
                 .functions(allFunctions);
 
-        if (functionHelper.getDefaultFunctionIsolationMode().equals(FunctionIsolationMode.NO_CONTAINER)) {
+        if (FunctionHelper.getDefaultFunctionIsolationMode().equals(FunctionIsolationMode.NO_CONTAINER)) {
             log.info("Isolation mode set to NoContainer in function defaults file, setting default isolation mode for the group to NoContainer");
 
             functionDefinitionVersionBuilder.defaultConfig(

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGreengrassHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGreengrassHelper.java
@@ -392,7 +392,7 @@ public class BasicGreengrassHelper implements GreengrassHelper {
             functionConfigurationBuilder.memorySize(null);
             functionBuilder.functionConfiguration(functionConfigurationBuilder.build());
 
-            log.info("Scrubbing memory size from function [" + function.functionArn() + "]");
+            log.warn("Scrubbing memory size from function [" + function.functionArn() + "] since it is running without Greengrass container isolation");
 
             return functionBuilder.build();
         };

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/interfaces/helpers/FunctionHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/interfaces/helpers/FunctionHelper.java
@@ -4,6 +4,7 @@ import com.awslabs.aws.greengrass.provisioner.data.conf.DeploymentConf;
 import com.awslabs.aws.greengrass.provisioner.data.conf.FunctionConf;
 import com.awslabs.aws.greengrass.provisioner.data.functions.BuildableFunction;
 import software.amazon.awssdk.services.greengrass.model.Function;
+import software.amazon.awssdk.services.greengrass.model.FunctionIsolationMode;
 import software.amazon.awssdk.services.iam.model.Role;
 
 import java.util.List;
@@ -13,6 +14,8 @@ public interface FunctionHelper {
     void setPathPrefix(String pathPrefix);
 
     List<FunctionConf> getFunctionConfObjects(Map<String, String> defaultEnvironment, DeploymentConf deploymentConf);
+
+    FunctionIsolationMode getDefaultFunctionIsolationMode();
 
     List<BuildableFunction> getBuildableFunctions(List<FunctionConf> functionConfs, Role lambdaRole);
 

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/interfaces/helpers/FunctionHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/interfaces/helpers/FunctionHelper.java
@@ -3,19 +3,44 @@ package com.awslabs.aws.greengrass.provisioner.interfaces.helpers;
 import com.awslabs.aws.greengrass.provisioner.data.conf.DeploymentConf;
 import com.awslabs.aws.greengrass.provisioner.data.conf.FunctionConf;
 import com.awslabs.aws.greengrass.provisioner.data.functions.BuildableFunction;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
 import software.amazon.awssdk.services.greengrass.model.Function;
 import software.amazon.awssdk.services.greengrass.model.FunctionIsolationMode;
 import software.amazon.awssdk.services.iam.model.Role;
 
+import java.io.File;
 import java.util.List;
 import java.util.Map;
 
 public interface FunctionHelper {
-    void setPathPrefix(String pathPrefix);
+    String FUNCTIONS = "functions";
+    String FUNCTION_DEFAULTS_CONF = "deployments/function.defaults.conf";
+    String URI = "uri";
+    String ARN = "arn";
+    String PATH = "path";
+    String READ_WRITE = "readWrite";
+    String TRAINING_JOB = "training-job";
+    String LOCAL_LAMBDA = "LOCAL_LAMBDA_";
+    String HTTPS = "https://";
+    String FUNCTION_CONF = "function.conf";
+    String CONF_GREENGRASS_CONTAINER = "conf.greengrassContainer";
+
+    static File getFunctionDefaultsFile() {
+        return new File(FUNCTION_DEFAULTS_CONF);
+    }
+
+    static Config getFunctionDefaults() {
+        return ConfigFactory.parseFile(getFunctionDefaultsFile());
+    }
+
+    static FunctionIsolationMode getDefaultFunctionIsolationMode() {
+        boolean greengrassContainer = getFunctionDefaults().getBoolean(CONF_GREENGRASS_CONTAINER);
+
+        return (greengrassContainer ? FunctionIsolationMode.GREENGRASS_CONTAINER : FunctionIsolationMode.NO_CONTAINER);
+    }
 
     List<FunctionConf> getFunctionConfObjects(Map<String, String> defaultEnvironment, DeploymentConf deploymentConf);
-
-    FunctionIsolationMode getDefaultFunctionIsolationMode();
 
     List<BuildableFunction> getBuildableFunctions(List<FunctionConf> functionConfs, Role lambdaRole);
 


### PR DESCRIPTION
This set of commits pulls the default container mode for the functions and then sets that default value in the function definition version.  It also automatically scrubs the memory size value from functions if they are set up to use the NoContainer isolation mode either explicitly or by inheriting the default.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
