### PR TITLE
Fix travis ci

### DIFF
--- a/src/test/java/GuiceInjectorTest.java
+++ b/src/test/java/GuiceInjectorTest.java
@@ -1,7 +1,14 @@
 import com.awslabs.aws.greengrass.provisioner.AwsGreengrassProvisioner;
+import org.junit.Before;
 import org.junit.Test;
 
 public class GuiceInjectorTest {
+    @Before
+    public void setup() {
+        // Prevents DefaultAwsRegionProviderChain failures in environments with no AWS configuration
+        System.setProperty("aws.region", "us-east-1");
+    }
+
     ///////////////////////////////////////////////////////////////////
     // These tests capture some injector related issues, but not all //
     ///////////////////////////////////////////////////////////////////


### PR DESCRIPTION
aws.region in the system properties needs to be set to allow environments without AWS credentials/config to run the tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
