### PR TITLE
Changed UnsupportedOperationExceptions to RuntimeExceptions

### DIFF
--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/data/Architecture.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/data/Architecture.java
@@ -58,7 +58,7 @@ public enum Architecture {
         try {
             return Optional.of(resource.toURI().toURL());
         } catch (MalformedURLException e) {
-            throw new UnsupportedOperationException(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/docker/AbstractDockerHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/docker/AbstractDockerHelper.java
@@ -86,7 +86,7 @@ public abstract class AbstractDockerHelper implements DockerHelper {
             }
 
             log.info("More than one repository found that matched [" + ecrRepositoryName.get() + "], cannot continue");
-            throw new UnsupportedOperationException("More than one matching ECR repository");
+            throw new RuntimeException("More than one matching ECR repository");
         } catch (RepositoryNotFoundException e) {
             log.info("Creating ECR repository [" + ecrRepositoryName.get() + "]");
             getEcrClient().createRepository(CreateRepositoryRequest.builder()
@@ -146,7 +146,7 @@ public abstract class AbstractDockerHelper implements DockerHelper {
                     .build(), groupName).id());
         } catch (DockerException | InterruptedException e) {
             log.error("Couldn't create container [" + e.getMessage() + "]");
-            throw new UnsupportedOperationException(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -168,7 +168,7 @@ public abstract class AbstractDockerHelper implements DockerHelper {
             }
         } catch (DockerException | InterruptedException e) {
             log.error("Couldn't start container [" + e.getMessage() + "]");
-            throw new UnsupportedOperationException(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -206,7 +206,7 @@ public abstract class AbstractDockerHelper implements DockerHelper {
             return Optional.empty();
         } catch (DockerException | InterruptedException e) {
             log.error("Failed to get container from image [" + e.getMessage() + "]");
-            throw new UnsupportedOperationException(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -243,7 +243,7 @@ public abstract class AbstractDockerHelper implements DockerHelper {
             log.info("Containers [" + listString + "]");
         } catch (DockerException | InterruptedException e) {
             log.error("Failed to list containers [" + e.getMessage() + "]");
-            throw new UnsupportedOperationException(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -269,7 +269,7 @@ public abstract class AbstractDockerHelper implements DockerHelper {
             dockerClient.stopContainer(container.id(), 5);
         } catch (DockerException | InterruptedException e) {
             log.error("Failed to stop container [" + e.getMessage() + "]");
-            throw new UnsupportedOperationException(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -279,7 +279,7 @@ public abstract class AbstractDockerHelper implements DockerHelper {
             dockerClient.pull(name, getDockerClientProvider().getRegistryAuthSupplier().authFor(""), getProgressHandler());
         } catch (DockerException | InterruptedException e) {
             log.error("Couldn't pull image [" + e.getMessage() + "]");
-            throw new UnsupportedOperationException(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/docker/GreengrassDockerHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/docker/GreengrassDockerHelper.java
@@ -133,7 +133,7 @@ public class GreengrassDockerHelper extends AbstractDockerHelper {
             if (errors.size() != 0) {
                 errors.stream()
                         .forEach(error -> log.error(error));
-                throw new UnsupportedOperationException("OEM extraction failed");
+                throw new RuntimeException("OEM extraction failed");
             }
 
             FileUtils.copyInputStreamToFile(coreCertStream.get(), tempDirectory.resolve(coreCertFilename).toFile());
@@ -142,7 +142,7 @@ public class GreengrassDockerHelper extends AbstractDockerHelper {
             FileUtils.copyInputStreamToFile(configJsonStream.get(), tempDirectory.resolve(configJsonFilename).toFile());
         } catch (IOException e) {
             log.error("Couldn't create temporary path for credentials");
-            throw new UnsupportedOperationException(e);
+            throw new RuntimeException(e);
         }
 
         try (DockerClient dockerClient = getDockerClient()) {
@@ -175,10 +175,10 @@ public class GreengrassDockerHelper extends AbstractDockerHelper {
             return Optional.of(containerCreation.id());
         } catch (DockerException | InterruptedException e) {
             log.error("Couldn't create container [" + e.getMessage() + "]");
-            throw new UnsupportedOperationException(e);
+            throw new RuntimeException(e);
         } catch (IOException e) {
             log.error("Couldn't copy files to container [" + e.getMessage() + "]");
-            throw new UnsupportedOperationException(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/docker/interfaces/DockerClientProvider.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/docker/interfaces/DockerClientProvider.java
@@ -37,7 +37,7 @@ public interface DockerClientProvider extends Provider<DockerClient> {
 
             @Override
             public RegistryAuth authForSwarm() throws DockerException {
-                throw new UnsupportedOperationException("Not implemented");
+                throw new RuntimeException("Not implemented");
             }
 
             @Override

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/builders/BasicGradleBuilder.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/builders/BasicGradleBuilder.java
@@ -70,7 +70,7 @@ public class BasicGradleBuilder implements GradleBuilder {
     @Override
     public void runGradle(Optional<File> gradleBuildPath, Optional<String> functionName) {
         if (!gradleBuildPath.isPresent()) {
-            throw new UnsupportedOperationException("gradle build path is not present.  This is a bug.");
+            throw new RuntimeException("gradle build path is not present.  This is a bug.");
         }
 
         // Guidance from: https://discuss.gradle.org/t/how-to-execute-a-gradle-task-from-java-code/7421
@@ -91,6 +91,6 @@ public class BasicGradleBuilder implements GradleBuilder {
 
     @Override
     public Optional<String> verifyHandlerExists(FunctionConf functionConf) {
-        throw new UnsupportedOperationException("Not implemented yet");
+        throw new RuntimeException("Not implemented yet");
     }
 }

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/builders/BasicMavenBuilder.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/builders/BasicMavenBuilder.java
@@ -223,7 +223,7 @@ public class BasicMavenBuilder implements MavenBuilder {
                 }
 
                 printDebugInfo(outputList, errorList);
-                throw new UnsupportedOperationException("Maven build failed");
+                throw new RuntimeException("Maven build failed");
             }
 
             if (functionName.isPresent()) {
@@ -236,7 +236,7 @@ public class BasicMavenBuilder implements MavenBuilder {
                 loggingHelper.logInfoWithName(log, "Internal [" + name + "]", "Finished Maven build");
             }
         } catch (MavenInvocationException e) {
-            throw new UnsupportedOperationException(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -299,6 +299,6 @@ public class BasicMavenBuilder implements MavenBuilder {
 
     @Override
     public Optional<String> verifyHandlerExists(FunctionConf functionConf) {
-        throw new UnsupportedOperationException("Not implemented yet");
+        throw new RuntimeException("Not implemented yet");
     }
 }

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/builders/BasicNodeBuilder.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/builders/BasicNodeBuilder.java
@@ -62,7 +62,7 @@ public class BasicNodeBuilder implements NodeBuilder {
             tempFile.deleteOnExit();
         } catch (IOException e) {
             e.printStackTrace();
-            throw new UnsupportedOperationException(e);
+            throw new RuntimeException(e);
         }
 
         // Create the deployment package
@@ -94,7 +94,7 @@ public class BasicNodeBuilder implements NodeBuilder {
                 }
             }
         } catch (Exception e) {
-            throw new UnsupportedOperationException(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/builders/BasicPythonBuilder.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/builders/BasicPythonBuilder.java
@@ -74,7 +74,7 @@ public class BasicPythonBuilder implements PythonBuilder {
             tempFile.deleteOnExit();
         } catch (IOException e) {
             e.printStackTrace();
-            throw new UnsupportedOperationException(e);
+            throw new RuntimeException(e);
         }
 
         // Get the directories, longest named directories first
@@ -129,7 +129,7 @@ public class BasicPythonBuilder implements PythonBuilder {
                 }
             }
         } catch (Exception e) {
-            throw new UnsupportedOperationException(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -145,7 +145,7 @@ public class BasicPythonBuilder implements PythonBuilder {
         try {
             return Files.list(functionConf.getBuildDirectory()).collect(Collectors.toList());
         } catch (IOException e) {
-            throw new UnsupportedOperationException(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicCloudFormationHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicCloudFormationHelper.java
@@ -98,7 +98,7 @@ public class BasicCloudFormationHelper implements CloudFormationHelper {
             if (stackStatus.equals(StackStatus.ROLLBACK_IN_PROGRESS) ||
                     (stackStatus.equals(StackStatus.ROLLBACK_COMPLETE)) ||
                     (stackStatus.equals(StackStatus.ROLLBACK_FAILED))) {
-                throw new UnsupportedOperationException("CloudFormation stack [" + stackName + "] failed to launch");
+                throw new RuntimeException("CloudFormation stack [" + stackName + "] failed to launch");
             }
 
             String action = "creating";

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicDeploymentHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicDeploymentHelper.java
@@ -130,7 +130,7 @@ public class BasicDeploymentHelper implements DeploymentHelper {
 
             return buildDeploymentConf(deploymentConfigFilename, config, groupName);
         } catch (ConfigException e) {
-            throw new UnsupportedOperationException(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -661,13 +661,13 @@ public class BasicDeploymentHelper implements DeploymentHelper {
                 pushContainerIfNecessary(deploymentArguments, imageId);
             } catch (DockerException e) {
                 log.error("Container build failed");
-                throw new UnsupportedOperationException(e);
+                throw new RuntimeException(e);
             } catch (InterruptedException e) {
                 log.error("Container build failed");
-                throw new UnsupportedOperationException(e);
+                throw new RuntimeException(e);
             } catch (IOException e) {
                 log.error("Container build failed");
-                throw new UnsupportedOperationException(e);
+                throw new RuntimeException(e);
             }
         }
 
@@ -1208,7 +1208,7 @@ public class BasicDeploymentHelper implements DeploymentHelper {
             if (mainScript == null) {
                 String message = "Main GGD script not found for [" + ggdConf.getScriptName() + "], exiting";
                 log.error(message);
-                throw new UnsupportedOperationException(message);
+                throw new RuntimeException(message);
             }
 
             File finalMainScript = mainScript;
@@ -1234,7 +1234,7 @@ public class BasicDeploymentHelper implements DeploymentHelper {
                 ggScriptTemplate.write("PAYLOAD:\n".getBytes());
                 ggScriptTemplate.write(getByteArrayOutputStream(installScriptVirtualTarEntries).get().toByteArray());
             } catch (IOException e) {
-                throw new UnsupportedOperationException(e);
+                throw new RuntimeException(e);
             }
 
             log.info("Writing script [" + ggShScriptName + "]");
@@ -1271,14 +1271,14 @@ public class BasicDeploymentHelper implements DeploymentHelper {
             try {
                 dockerClient.tag(imageId, String.join(":", shortEcrEndpointAndRepo, deploymentArguments.groupName));
             } catch (DockerException e) {
-                throw new UnsupportedOperationException(e);
+                throw new RuntimeException(e);
             }
 
             try {
                 dockerClient.push(shortEcrEndpointAndRepo, basicProgressHandler, normalDockerClientProvider.getRegistryAuthSupplier().authFor(""));
             } catch (DockerException e) {
                 log.error("Docker push failed [" + e.getMessage() + "]");
-                throw new UnsupportedOperationException(e);
+                throw new RuntimeException(e);
             }
         }
 
@@ -1331,7 +1331,7 @@ public class BasicDeploymentHelper implements DeploymentHelper {
         try {
             baos = archiveHelper.tar(virtualTarEntries);
         } catch (IOException e) {
-            throw new UnsupportedOperationException(e);
+            throw new RuntimeException(e);
         }
 
         return baos;

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicFunctionHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicFunctionHelper.java
@@ -68,7 +68,7 @@ public class BasicFunctionHelper implements FunctionHelper {
                 String[] components = tempFunctionName.split("/");
 
                 if (components.length < 3) {
-                    throw new UnsupportedOperationException("The git URL specified [" + functionName + "] is in a format that was not understood (1)");
+                    throw new RuntimeException("The git URL specified [" + functionName + "] is in a format that was not understood (1)");
                 }
 
                 String last = components[components.length - 1];
@@ -81,7 +81,7 @@ public class BasicFunctionHelper implements FunctionHelper {
                     String[] repoAndDirectory = last.split(":");
 
                     if (repoAndDirectory.length != 2) {
-                        throw new UnsupportedOperationException("The git URL specified [" + functionName + "] is in a format that was not understood (2)");
+                        throw new RuntimeException("The git URL specified [" + functionName + "] is in a format that was not understood (2)");
                     }
 
                     repoName = repoAndDirectory[0];
@@ -98,7 +98,7 @@ public class BasicFunctionHelper implements FunctionHelper {
                 File functionConf = tempDir.resolve(directoryName).resolve(FUNCTION_CONF).toFile();
 
                 if (!functionConf.exists()) {
-                    throw new UnsupportedOperationException("This function and repo doesn't contain a function.conf");
+                    throw new RuntimeException("This function and repo doesn't contain a function.conf");
                 }
 
                 return functionConf;
@@ -122,7 +122,7 @@ public class BasicFunctionHelper implements FunctionHelper {
                 return tempPath.resolve(FUNCTION_CONF).toFile();
             }
         } catch (IOException e) {
-            throw new UnsupportedOperationException(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -151,7 +151,7 @@ public class BasicFunctionHelper implements FunctionHelper {
         } else if (exitVal.get() != 0) {
             // Error
             stderrStrings.stream().forEach(log::error);
-            throw new UnsupportedOperationException("An error occurred while checking out the git repo");
+            throw new RuntimeException("An error occurred while checking out the git repo");
         }
         return tempDir;
     }
@@ -241,7 +241,7 @@ public class BasicFunctionHelper implements FunctionHelper {
                     functionConfBuilder.cfTemplate(cfTemplate);
                 }
             } catch (ConfigException e) {
-                throw new UnsupportedOperationException(e);
+                throw new RuntimeException(e);
             }
 
             FunctionConf functionConf = functionConfBuilder.build();
@@ -280,7 +280,7 @@ public class BasicFunctionHelper implements FunctionHelper {
             log.error("Missing config files (this is NOT OK in normal deployments): ");
             missingConfigFunctions.stream()
                     .forEach(functionName -> log.error("  " + functionName));
-            throw new UnsupportedOperationException("Missing configuration files, can not build deployment");
+            throw new RuntimeException("Missing configuration files, can not build deployment");
         }
     }
 
@@ -401,21 +401,21 @@ public class BasicFunctionHelper implements FunctionHelper {
             String[] arnComponents = arn.split(":");
 
             if (arnComponents.length != 6) {
-                throw new UnsupportedOperationException("SageMaker ARN looks malformed [" + arn + "]");
+                throw new RuntimeException("SageMaker ARN looks malformed [" + arn + "]");
             }
 
             if (!arnComponents[2].equals("sagemaker")) {
-                throw new UnsupportedOperationException("SageMaker ARN does not look like a SageMaker ARN [" + arn + "]");
+                throw new RuntimeException("SageMaker ARN does not look like a SageMaker ARN [" + arn + "]");
             }
 
             arnComponents = arnComponents[5].split("/");
 
             if (arnComponents.length < 2) {
-                throw new UnsupportedOperationException("SageMaker ARN looks malformed [" + arn + "]");
+                throw new RuntimeException("SageMaker ARN looks malformed [" + arn + "]");
             }
 
             if (!arnComponents[0].equals(TRAINING_JOB)) {
-                throw new UnsupportedOperationException("SageMaker ARNs must be training job ARNs, not model ARNs or other types of ARNs [" + arn + "]");
+                throw new RuntimeException("SageMaker ARNs must be training job ARNs, not model ARNs or other types of ARNs [" + arn + "]");
             }
 
             Optional<String> name = getName(temp);

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGGDHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGGDHelper.java
@@ -62,7 +62,7 @@ public class BasicGGDHelper implements GGDHelper {
             log.error("The configuration file for the GGD may be missing");
             System.exit(1);
         } catch (ConfigException e) {
-            throw new UnsupportedOperationException(e);
+            throw new RuntimeException(e);
         }
 
         GGDConf ggdConf = ggdConfBuilder.build();

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGreengrassHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGreengrassHelper.java
@@ -760,7 +760,7 @@ public class BasicGreengrassHelper implements GreengrassHelper {
                     .collect(Collectors.joining(", "));
 
             log.error("Duplicate local device resource source paths defined [" + duplicatesString + "].  Greengrass will not accept this configuration.");
-            throw new UnsupportedOperationException("Invalid resource configuration");
+            throw new RuntimeException("Invalid resource configuration");
         }
     }
 
@@ -777,7 +777,7 @@ public class BasicGreengrassHelper implements GreengrassHelper {
                     .collect(Collectors.joining(", "));
 
             log.error("Duplicate local volume resource source paths defined [" + duplicatesString + "].  Greengrass will not accept this configuration.");
-            throw new UnsupportedOperationException("Invalid resource configuration");
+            throw new RuntimeException("Invalid resource configuration");
         }
     }
 
@@ -794,7 +794,7 @@ public class BasicGreengrassHelper implements GreengrassHelper {
                     .collect(Collectors.joining(", "));
 
             log.error("Duplicate local SageMaker resource destination paths defined [" + duplicatesString + "].  Greengrass will not accept this configuration.");
-            throw new UnsupportedOperationException("Invalid resource configuration");
+            throw new RuntimeException("Invalid resource configuration");
         }
     }
 
@@ -811,7 +811,7 @@ public class BasicGreengrassHelper implements GreengrassHelper {
                     .collect(Collectors.joining(", "));
 
             log.error("Duplicate local S3 resource destination paths defined [" + duplicatesString + "].  Greengrass will not accept this configuration.");
-            throw new UnsupportedOperationException("Invalid resource configuration");
+            throw new RuntimeException("Invalid resource configuration");
         }
     }
 
@@ -844,13 +844,13 @@ public class BasicGreengrassHelper implements GreengrassHelper {
         try {
             iotHelper.getThingArn(thingName);
         } catch (ResourceNotFoundException e) {
-            throw new UnsupportedOperationException("Thing [" + thingName + "] does not exist");
+            throw new RuntimeException("Thing [" + thingName + "] does not exist");
         }
 
         String certificateArn = iotHelper.getThingPrincipal(thingName);
 
         if (certificateArn == null) {
-            throw new UnsupportedOperationException("Thing [" + thingName + "] does not have a certificate attached");
+            throw new RuntimeException("Thing [" + thingName + "] does not have a certificate attached");
         }
 
         return Device.builder()

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGroupQueryHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGroupQueryHelper.java
@@ -100,7 +100,7 @@ public class BasicGroupQueryHelper implements GroupQueryHelper {
             return;
         }
 
-        throw new UnsupportedOperationException("This should never happen.  This is a bug.");
+        throw new RuntimeException("This should never happen.  This is a bug.");
     }
 
     private void writeToFile(QueryArguments queryArguments, String output, String outputFilename) {

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGroupUpdateHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGroupUpdateHelper.java
@@ -86,7 +86,7 @@ public class BasicGroupUpdateHelper implements GroupUpdateHelper {
             return;
         }
 
-        throw new UnsupportedOperationException("This should never happen.  This is a bug.");
+        throw new RuntimeException("This should never happen.  This is a bug.");
     }
 
     private void removeDevice(UpdateArguments updateArguments, GroupInformation groupInformation) {
@@ -359,7 +359,7 @@ public class BasicGroupUpdateHelper implements GroupUpdateHelper {
             subscriptions.remove(subscriptionToRemove);
             log.info("Subscription removed [" + subscriptionToRemove.source() + ", " + subscriptionToRemove.target() + ", " + subscriptionToRemove.subject() + "]");
         } else {
-            throw new UnsupportedOperationException("This should never happen.  This is a bug.");
+            throw new RuntimeException("This should never happen.  This is a bug.");
         }
 
         String newSubscriptionDefinitionVersionArn = greengrassHelper.createSubscriptionDefinitionAndVersion(subscriptions);

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicIotHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicIotHelper.java
@@ -51,7 +51,7 @@ public class BasicIotHelper implements IotHelper {
                 return iotClient.describeThing(describeThingRequest).thingArn();
             }
 
-            throw new UnsupportedOperationException(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicLambdaHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicLambdaHelper.java
@@ -64,13 +64,13 @@ public class BasicLambdaHelper implements LambdaHelper {
 
             zipFilePath = mavenBuilder.getArchivePath(functionConf);
             */
-            throw new UnsupportedOperationException("This function [" + functionConf.getFunctionName() + "] is a Maven project but Maven support is currently disabled.  If you need this feature please file a Github issue.");
+            throw new RuntimeException("This function [" + functionConf.getFunctionName() + "] is a Maven project but Maven support is currently disabled.  If you need this feature please file a Github issue.");
         } else if (gradleBuilder.isGradleFunction(functionConf)) {
             gradleBuilder.buildJavaFunctionIfNecessary(functionConf);
 
             zipFilePath = gradleBuilder.getArchivePath(functionConf);
         } else {
-            throw new UnsupportedOperationException("This function [" + functionConf.getFunctionName() + "] is neither a Maven project nor a Gradle project.  It cannot be built automatically.");
+            throw new RuntimeException("This function [" + functionConf.getFunctionName() + "] is neither a Maven project nor a Gradle project.  It cannot be built automatically.");
         }
 
         return createFunctionIfNecessary(functionConf, Runtime.JAVA8, role, zipFilePath);
@@ -152,7 +152,7 @@ public class BasicLambdaHelper implements LambdaHelper {
                     counter++;
 
                     if (counter > 10) {
-                        throw new UnsupportedOperationException("Something went wrong with the Lambda IAM role, try again later");
+                        throw new RuntimeException("Something went wrong with the Lambda IAM role, try again later");
                     }
 
                     log.warn("Waiting for IAM role to be available to AWS Lambda...");

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicResourceHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicResourceHelper.java
@@ -28,7 +28,7 @@ public class BasicResourceHelper implements ResourceHelper {
         try {
             return getResource(resourcePath).openStream();
         } catch (IOException e) {
-            throw new UnsupportedOperationException(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -74,7 +74,7 @@ public class BasicResourceHelper implements ResourceHelper {
 
             return tempFile.toString();
         } catch (Exception e) {
-            throw new UnsupportedOperationException(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/interfaces/builders/ScriptingFunctionBuilder.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/interfaces/builders/ScriptingFunctionBuilder.java
@@ -81,7 +81,7 @@ public interface ScriptingFunctionBuilder extends FunctionBuilder {
                 }
             }
         } catch (Exception e) {
-            throw new UnsupportedOperationException(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -95,7 +95,7 @@ public interface ScriptingFunctionBuilder extends FunctionBuilder {
             Files.move(tempFile.toPath(), new File(getArchivePath(functionConf)).toPath(), StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException e) {
             e.printStackTrace();
-            throw new UnsupportedOperationException(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/interfaces/helpers/ExecutorHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/interfaces/helpers/ExecutorHelper.java
@@ -22,13 +22,13 @@ public interface ExecutorHelper {
                         try {
                             return future.get();
                         } catch (Exception e) {
-                            throw new UnsupportedOperationException(e);
+                            throw new RuntimeException(e);
                         }
                     })
                     .collect(Collectors.toList());
         } catch (InterruptedException e) {
             log.error("Parallel task execution failed [" + e.getMessage() + "]");
-            throw new UnsupportedOperationException(e);
+            throw new RuntimeException(e);
         } finally {
             // Clean up the executor
             executorService.shutdown();

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/interfaces/helpers/IoHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/interfaces/helpers/IoHelper.java
@@ -24,9 +24,9 @@ public interface IoHelper {
         try (FileOutputStream out = new FileOutputStream(filename)) {
             out.write(contents);
         } catch (FileNotFoundException e) {
-            throw new UnsupportedOperationException(e);
+            throw new RuntimeException(e);
         } catch (IOException e) {
-            throw new UnsupportedOperationException(e);
+            throw new RuntimeException(e);
         }
 
         makeWritable(filename);
@@ -40,7 +40,7 @@ public interface IoHelper {
         try {
             return Files.readAllBytes(Paths.get(filename));
         } catch (IOException e) {
-            throw new UnsupportedOperationException(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -54,7 +54,7 @@ public interface IoHelper {
         try {
             return Files.readAllBytes(file.toPath());
         } catch (IOException e) {
-            throw new UnsupportedOperationException(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -72,7 +72,7 @@ public interface IoHelper {
 
             return baos.toByteArray();
         } catch (IOException e) {
-            throw new UnsupportedOperationException(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -84,7 +84,7 @@ public interface IoHelper {
             FileOutputStream fos = new FileOutputStream(file);
             fos.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
         } catch (IOException e) {
-            throw new UnsupportedOperationException(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -92,7 +92,7 @@ public interface IoHelper {
         try {
             return new Scanner(new URL(url).openStream(), "UTF-8").useDelimiter("\\A").next();
         } catch (IOException e) {
-            throw new UnsupportedOperationException(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -142,7 +142,7 @@ public interface IoHelper {
 
             return object;
         } catch (Exception e) {
-            throw new UnsupportedOperationException(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -159,7 +159,7 @@ public interface IoHelper {
 
             return Hex.encodeHexString(sha1.digest()).toLowerCase();
         } catch (Exception e) {
-            throw new UnsupportedOperationException(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -188,16 +188,16 @@ public interface IoHelper {
             return KeysAndCertificate.from((CreateKeysAndCertificateResult) object);
         }
 
-        throw new UnsupportedOperationException("Couldn't deserialize keys.  This is a bug.");
+        throw new RuntimeException("Couldn't deserialize keys.  This is a bug.");
     }
 
     default Optional<InputStream> extractTar(String tarFile, String filenameToExtract) {
         try (final TarArchiveInputStream tarIn = new TarArchiveInputStream(new FileInputStream(new File(tarFile)))) {
             return getInputStreamFromTar(tarIn, filenameToExtract);
         } catch (FileNotFoundException e) {
-            throw new UnsupportedOperationException(e);
+            throw new RuntimeException(e);
         } catch (IOException e) {
-            throw new UnsupportedOperationException(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -205,9 +205,9 @@ public interface IoHelper {
         try (final TarArchiveInputStream tarIn = new TarArchiveInputStream(new GZIPInputStream(new FileInputStream(new File(tarGzFile))))) {
             return getInputStreamFromTar(tarIn, filenameToExtract);
         } catch (FileNotFoundException e) {
-            throw new UnsupportedOperationException(e);
+            throw new RuntimeException(e);
         } catch (IOException e) {
-            throw new UnsupportedOperationException(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/interfaces/helpers/SafeProvider.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/interfaces/helpers/SafeProvider.java
@@ -12,7 +12,7 @@ public interface SafeProvider<T> extends Provider<T> {
             sdkErrorHandler.handleSdkError(e);
         }
 
-        throw new UnsupportedOperationException("You should never reach here, this is a bug");
+        throw new RuntimeException("You should never reach here, this is a bug");
     }
 
     T unsafeGet();


### PR DESCRIPTION
RuntimeException makes more sense for these errors. They shouldn't be UnsupportedOperationExceptions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
