### PR TITLE
Add hsi softhsm2 support

### DIFF
--- a/docs/DeploymentCommandLine.md
+++ b/docs/DeploymentCommandLine.md
@@ -146,3 +146,11 @@ Long form: `--ggd`
 Generates the Greengrass Device scripts that can be used to test the core's connectivity info and discovery information.
 This is stored in `build/ggd.GROUP_NAME.sh` which will extract the GGD scripts, configuration, and certificates when a
 user runs it.
+
+## Use SoftHSM2 for Greengrass Hardware Security Integration (HSI)
+
+Long form: `--hsi-softhsm2`
+
+Generates a configuration and bootstrap scripts that use Greengrass Hardware Security Integration (HSI) with SoftHSM2. Only
+works on Ubuntu. This can be used to test out HSI but is not for production use as it only simulates hardware security.
+Works with `--ec2-launch`.

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/data/arguments/DeploymentArguments.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/data/arguments/DeploymentArguments.java
@@ -23,6 +23,7 @@ public class DeploymentArguments extends Arguments {
     private final String LONG_NO_SYSTEMD_OPTION = "--no-systemd";
     private final String LONG_EC2_LAUNCH_OPTION = "--ec2-launch";
     private final String LONG_DOCKER_LAUNCH_OPTION = "--docker-launch";
+    private final String LONG_HSI_SOFTHSM2_OPTION = "--hsi-softhsm2";
     //    private static final String LONG_DOCKER_SCRIPT_OUTPUT_OPTION = "--docker-script";
 
     @Parameter(names = {LONG_ARCHITECTURE_OPTION, SHORT_ARCHITECTURE_OPTION}, description = "Architecture (X86_64, ARM32, ARM64)")
@@ -52,6 +53,8 @@ public class DeploymentArguments extends Arguments {
     public boolean ec2Launch;
     @Parameter(names = {LONG_DOCKER_LAUNCH_OPTION}, description = "Launch an this deployment in a Docker container locally")
     public boolean dockerLaunch;
+    @Parameter(names = {LONG_HSI_SOFTHSM2_OPTION}, description = "Use Greengrass Hardware Security Integration (HSI) with SoftHSM2")
+    public boolean hsiSoftHsm2;
     //    @Parameter(names = {LONG_DOCKER_SCRIPT_OUTPUT_OPTION}, description = "Generate a script to install Docker and run the Greengrass container [docker.GROUP_NAME.sh] (implies " + LONG_BUILD_CONTAINER_OPTION + ")")
     //    public boolean dockerScriptOutput;
     @Parameter(names = "--help", help = true)

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicDeploymentArgumentHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicDeploymentArgumentHelper.java
@@ -93,6 +93,7 @@ public class BasicDeploymentArgumentHelper implements DeploymentArgumentHelper {
         deploymentArguments.noSystemD = getValueOrDefault(deploymentArguments.noSystemD, getBooleanDefault(defaults, "conf.noSystemD"));
         deploymentArguments.ec2Launch = getValueOrDefault(deploymentArguments.ec2Launch, getBooleanDefault(defaults, "conf.ec2Launch"));
         deploymentArguments.dockerLaunch = getValueOrDefault(deploymentArguments.dockerLaunch, getBooleanDefault(defaults, "conf.dockerLaunch"));
+        deploymentArguments.hsiSoftHsm2 = getValueOrDefault(deploymentArguments.hsiSoftHsm2, getBooleanDefault(defaults, "conf.hsiSoftHsm2"));
 
         if (deploymentArguments.ec2Launch && deploymentArguments.dockerLaunch) {
             throw new RuntimeException("The EC2 and Docker launch options are mutually exclusive.  Only specify one of them.");
@@ -108,6 +109,15 @@ public class BasicDeploymentArgumentHelper implements DeploymentArgumentHelper {
             }
         }
 
+        if (deploymentArguments.hsiSoftHsm2 && deploymentArguments.dockerLaunch) {
+            throw new RuntimeException("HSI with SoftHSM2 is not supported in Docker yet");
+        }
+
+        if (deploymentArguments.hsiSoftHsm2) {
+            // Force script output with HSI SoftHSM2
+            deploymentArguments.scriptOutput = true;
+        }
+
         if (deploymentArguments.dockerLaunch) {
             // Force OEM file output with Docker launch
             deploymentArguments.oemOutput = true;
@@ -121,6 +131,9 @@ public class BasicDeploymentArgumentHelper implements DeploymentArgumentHelper {
             deploymentArguments.groupName = Nomen.est().separator("-").space("-").adjective().pokemon().get();
             // Filter out dot characters, sometimes the library uses the value "jr." which is not allowed in a group name
             deploymentArguments.groupName = deploymentArguments.groupName.replaceAll("\\.", "");
+            // Filter out normal apostrophes, and special apostrophes (from "farfetch’d")
+            deploymentArguments.groupName = deploymentArguments.groupName.replaceAll("'", "");
+            deploymentArguments.groupName = deploymentArguments.groupName.replaceAll("’", "");
             log.info("No group name specified, group name auto-generated [" + deploymentArguments.groupName + "]");
         }
 

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicJsonHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicJsonHelper.java
@@ -13,11 +13,16 @@ public class BasicJsonHelper implements JsonHelper {
 
     @Override
     public String toJson(Object object) {
-        return new GsonBuilder().setPrettyPrinting().create().toJson(object);
+        return new GsonBuilder()
+                .disableHtmlEscaping()
+                .setPrettyPrinting()
+                .create()
+                .toJson(object);
     }
 
     @Override
     public <T> T fromJson(Class<T> clazz, byte[] json) {
-        return new Gson().fromJson(new String(json), clazz);
+        return new Gson()
+                .fromJson(new String(json), clazz);
     }
 }

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/interfaces/helpers/ConfigFileHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/interfaces/helpers/ConfigFileHelper.java
@@ -4,5 +4,12 @@ import com.awslabs.aws.greengrass.provisioner.data.arguments.DeploymentArguments
 import software.amazon.awssdk.regions.Region;
 
 public interface ConfigFileHelper {
-    String generateConfigJson(String caPath, String certPath, String keyPath, String coreThingArn, String iotHost, Region region, DeploymentArguments deploymentArguments, boolean functionsRunningAsRoot);
+    String generateConfigJson(String caPath,
+                              String certPath,
+                              String keyPath,
+                              String coreThingArn,
+                              String iotHost,
+                              Region region,
+                              DeploymentArguments deploymentArguments,
+                              boolean functionsRunningAsRoot);
 }

--- a/src/main/resources/shell/template.sh.in
+++ b/src/main/resources/shell/template.sh.in
@@ -304,6 +304,34 @@ if [ -d "${SYSTEMD_DESTINATION_PATH}" ]; then
     fi
 fi
 
+grep -q libsofthsm2.so /greengrass/config/config.json
+
+if [ $? -eq 0 ]; then
+  echo "HSI with SoftHSM2 in use"
+
+  if [ "$INSTALLER" == "apt-get" ]; then
+    # Find libsofthsm2.so, ignore the one in the greengrass directory
+    $INSTALLER install -y softhsm2 libsofthsm2-dev pkcs11-dump
+
+    LIBSOFTHSM_LOCATION=`dpkg -L libsofthsm2 | grep libsofthsm2.so | head -n 1`
+    ln -sf $LIBSOFTHSM_LOCATION /greengrass/libsofthsm2.so
+
+    # NOTE: This symlink is not necessary yet
+    # LIBP11KIT_LOCATION=`dpkg -L libp11-kit0 | grep libp11-kit.so.0 | head -n 1`
+    # ln -sf $LIBP11KIT_LOCATION /greengrass/libp11-kit.so.0
+
+    SOFTHSMCONF_LOCATION=`strings /greengrass/libsofthsm2.so | grep '^[a-zA-Z0-9./]*conf$'`
+    mkdir -p /greengrass/softhsm2/tokens
+    echo "directories.tokendir = /greengrass/softhsm2/tokens" > $SOFTHSMCONF_LOCATION
+    echo "objectstore.backend = file" >> $SOFTHSMCONF_LOCATION
+    softhsm2-util --init-token --slot 0 --label greengrass --so-pin 12345 --pin 1234
+    openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt -in /greengrass/certs/core.key -out hash.private.pem
+    softhsm2-util --import hash.private.pem --slot 0 --label iotkey --id 0000 --pin 1234
+  else
+    echo "HSI with SoftHSM2 support is only available in Ubuntu/Debian currently, this deployment will fail. Please try this on an Ubuntu system instead."
+  fi
+fi
+
 # At this point everything has been deployed, mark the script as deployed
 mv $SCRIPT_NAME $SCRIPT_NAME.DEPLOYED
 

--- a/src/main/resources/shell/template.sh.in
+++ b/src/main/resources/shell/template.sh.in
@@ -326,7 +326,14 @@ if [ $? -eq 0 ]; then
     echo "objectstore.backend = file" >> $SOFTHSMCONF_LOCATION
     softhsm2-util --init-token --slot 0 --label greengrass --so-pin 12345 --pin 1234
     openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt -in /greengrass/certs/core.key -out hash.private.pem
-    softhsm2-util --import hash.private.pem --slot 0 --label iotkey --id 0000 --pin 1234
+
+    SOFTHSM2_UTIL_VERSION=`softhsm2-util --version`
+
+    if [ "$SOFTHSM2_UTIL_VERSION" == "2.0.0" ]; then
+      softhsm2-util --import hash.private.pem --slot 0 --label iotkey --id 0000 --pin 1234
+    else
+      softhsm2-util --import hash.private.pem --token greengrass --label iotkey --id 0000 --pin 1234
+    fi
   else
     echo "HSI with SoftHSM2 support is only available in Ubuntu/Debian currently, this deployment will fail. Please try this on an Ubuntu system instead."
   fi


### PR DESCRIPTION
Added initial support for SoftHSM2.  Works on EC2 instances and local systems running Ubuntu.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
