### PR TITLE
Fix for #44 - Greengrass Docker image name updated

### DIFF
--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGGConstants.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGGConstants.java
@@ -72,7 +72,7 @@ public class BasicGGConstants implements GGConstants {
     private String buildOfficialGreengrassDockerImageString() {
         return String.join("/",
                 getOfficialGreengrassEcrEndpoint(),
-                "aws-greengrass-docker/amazonlinux:latest");
+                "aws-iot-greengrass:latest");
     }
 
     @Override


### PR DESCRIPTION
Name of the official container changed, fixed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
