### PR TITLE
Prevent failure to read SSH keys when .ssh directory contains subdirectories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ def mockitoVersion = '1.10.19'
 def lombokVersion = '1.18.6'
 def vavrVersion = '0.9.2'
 def httpClientVersion = '4.5.7'
+def jodahFailsafeVersion = '2.0.1'
 
 def buildDirDist = "$buildDir/dist"
 def buildDirTemp = "$buildDir/temp"
@@ -204,6 +205,10 @@ dependencies {
     compile "io.vavr:vavr:$vavrVersion"
     // Dependency added to fix - https://github.com/aws/aws-sdk-java-v2/issues/652
     compile "org.apache.httpcomponents:httpclient:$httpClientVersion"
+
+    // https://mvnrepository.com/artifact/net.jodah/failsafe
+    compile "net.jodah:failsafe:$jodahFailsafeVersion"
+
 
     testCompile "junit:junit:$junitVersion"
     testCompile "org.mockito:mockito-all:$mockitoVersion"

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicIoHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicIoHelper.java
@@ -41,9 +41,12 @@ public class BasicIoHelper implements IoHelper {
 
         Path sshDirectory = new File(String.join("/", optionalHomeDirectory.get(), ".ssh")).toPath();
 
-        return Files.list(sshDirectory)
-                .filter(path -> readFileAsString(path.toFile()).contains("BEGIN RSA PRIVATE KEY"))
-                .map(Path::toString)
+        // Recursively get all of the files in the directory, only look at regular files, and make sure they look like private keys
+        return Files.walk(sshDirectory)
+                .filter(Files::isRegularFile)
+                .map(Path::toFile)
+                .filter(file -> readFileAsString(file).contains("BEGIN RSA PRIVATE KEY"))
+                .map(File::toString)
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
Fix for #55 

Also, added retries for security group visibility as an issue came up with that in testing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
