### PR TITLE
deploy.sh completes if not in .git repository

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -13,7 +13,11 @@ fi
 
 PWD=$(pwd)
 
-TAG=`git symbolic-ref --short HEAD`
+if git symbolic-ref --short HEAD > /dev/null 2>&1 ; then
+  TAG=`git symbolic-ref --short HEAD`
+else
+  TAG=latest
+fi
 
 docker pull timmattison/aws-greengrass-provisioner:$TAG
 


### PR DESCRIPTION
*Issue:*
The main document calls out to save `deploy.sh` locally and execute. If this is done outside the context of git repository, the script fails on the `git symbolic-ref --short HEAD` command and never completes.

*Description of changes:*
This change detects if `deploy.sh` is being run from within a repo where the git tag can be found. If it is not found, *latest* is applied as the tag for the pulled repository.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
