### PR TITLE
Cleaner retry logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ build
 .gradle
 *.swp
 /out
+*.jar


### PR DESCRIPTION
Cleaned up retry logic for Lambda IAM role checks with RetryPolicy instead of loops

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
