### PR TITLE
Fix aws-greengrass-provisioner-71, added retry and delay in bash script for package manager updates

### DIFF
--- a/src/main/resources/shell/template.sh.in
+++ b/src/main/resources/shell/template.sh.in
@@ -217,7 +217,20 @@ if [ "$UPDATE_DEPENDENCIES" = true ]; then
         PIP_PACKAGES=
     fi
 
-    $INSTALLER update -y
+    COUNTER=0
+
+    until $INSTALLER update -y || (( COUNTER++ >= 3 ));
+    do
+      echo "Package manager update failed, trying again"
+      sleep 2
+    done
+
+    if [ "$COUNTER" -gt 3 ];
+    then
+      echo "Failed to run package manager update, can't continue"
+      exit 1
+    fi
+
     $INSTALLER install -y sqlite3 bzip2 $PIP_PACKAGES git
     $INSTALLER install -y $INSTALLER_SPECIFIC_PACKAGES
     $INSTALLER install -y mosh


### PR DESCRIPTION
Fix #71 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
