### PR TITLE
Greengrass 1.9.1 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/awslabs/aws-greengrass-provisioner.svg?branch=master)](https://travis-ci.org/awslabs/aws-greengrass-provisioner)
 
-**Note: GGP expects to be used with Greengrass Core 1.9.0 only!**
+**Note: GGP expects to be used with Greengrass Core 1.9.1 only!**
 
 Simplifies provisioning Greengrass Cores and building Greengrass Lambda functions.  GGP configures Greengrass so you don't have to.
 

--- a/build.gradle
+++ b/build.gradle
@@ -58,9 +58,9 @@ def buildDirFoundation = "$buildDir/foundation"
 task downloadGreengrassBinaries(type: Download) {
     // Download the Greengrass binaries into the dist directory so they can be packaged into the JAR
     src(
-            ['https://d1onfpft10uf5o.cloudfront.net/greengrass-core/downloads/1.9.0/greengrass-linux-aarch64-1.9.0.tar.gz',
-             'https://d1onfpft10uf5o.cloudfront.net/greengrass-core/downloads/1.9.0/greengrass-linux-armv7l-1.9.0.tar.gz',
-             'https://d1onfpft10uf5o.cloudfront.net/greengrass-core/downloads/1.9.0/greengrass-linux-x86-64-1.9.0.tar.gz']
+            ['https://d1onfpft10uf5o.cloudfront.net/greengrass-core/downloads/1.9.1/greengrass-linux-aarch64-1.9.1.tar.gz',
+             'https://d1onfpft10uf5o.cloudfront.net/greengrass-core/downloads/1.9.1/greengrass-linux-armv7l-1.9.1.tar.gz',
+             'https://d1onfpft10uf5o.cloudfront.net/greengrass-core/downloads/1.9.1/greengrass-linux-x86-64-1.9.1.tar.gz']
     )
     dest "$buildDirDist"
     overwrite false

--- a/src/integration-test/java/GreengrassDeploymentsIT.java
+++ b/src/integration-test/java/GreengrassDeploymentsIT.java
@@ -237,7 +237,7 @@ public class GreengrassDeploymentsIT {
         AwsGreengrassProvisioner.main(split(LIFX_DEPLOYMENT_COMMAND));
     }
 
-    // Test set 4: Expected success with Python LiFX function (has dependencies to fetch)
+    // Test set 4: Expected success with Node Hello World
     @Test
     public void shouldBuildNodeFunctionWithDocker() {
         runContainer(NODE_HELLO_WORLD_DEPLOYMENT_COMMAND, equalTo(0));
@@ -251,7 +251,7 @@ public class GreengrassDeploymentsIT {
         Assert.assertThat(genericContainer.getCurrentContainerInfo().getState().getExitCode(), is(integerMatcher));
     }
 
-    // Test set 4: Expected success with Python LiFX function (has dependencies to fetch)
+    // Test set 4: Expected success with Node Hello World
     @Test
     public void shouldBuildNodeFunctionWithoutDocker() {
         AwsGreengrassProvisioner.main(split(NODE_HELLO_WORLD_DEPLOYMENT_COMMAND));

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/data/Architecture.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/data/Architecture.java
@@ -12,9 +12,9 @@ import java.util.stream.Collectors;
 import static com.google.common.io.Resources.getResource;
 
 public enum Architecture {
-    ARM32("greengrass-linux-armv7l-1.9.1.tar.gz", "dd61136e491bfa77503ede9ed3d59538c9c30add"),
-    X86_64("greengrass-linux-x86-64-1.9.1.tar.gz", "1a1483daa4b1f2062fba47feff1ecf59cddbc1ec"),
-    ARM64("greengrass-linux-aarch64-1.9.1.tar.gz", "c949da81abbf9f2be43758f4dcc529732b38f691");
+    ARM32("greengrass-linux-armv7l-1.9.1.tar.gz"),
+    X86_64("greengrass-linux-x86-64-1.9.1.tar.gz"),
+    ARM64("greengrass-linux-aarch64-1.9.1.tar.gz");
 
     @Getter
     private final String DIST = "dist";
@@ -22,18 +22,14 @@ public enum Architecture {
     @Getter
     private final String filename;
 
-    @Getter
-    private final String hash;
-
     @Getter(lazy = true)
     private final String resourcePath = innerGetResourcePath();
 
     @Getter(lazy = true)
     private final Optional<URL> resourceUrl = innerGetResourceUrl();
 
-    Architecture(String filename, String hash) {
+    Architecture(String filename) {
         this.filename = filename;
-        this.hash = hash;
     }
 
     public static String getList() {

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/data/Architecture.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/data/Architecture.java
@@ -12,9 +12,9 @@ import java.util.stream.Collectors;
 import static com.google.common.io.Resources.getResource;
 
 public enum Architecture {
-    ARM32("greengrass-linux-armv7l-1.9.0.tar.gz", "e4616805e9e6a14670e6dc6da4d1597e56b6035a"),
-    X86_64("greengrass-linux-x86-64-1.9.0.tar.gz", "cdf4ae25ca0c7807c4b0d49862e95c361f444db0"),
-    ARM64("greengrass-linux-aarch64-1.9.0.tar.gz", "0b84d590dc1eed7678fd13ce1474065f1a3ac419");
+    ARM32("greengrass-linux-armv7l-1.9.1.tar.gz", "dd61136e491bfa77503ede9ed3d59538c9c30add"),
+    X86_64("greengrass-linux-x86-64-1.9.1.tar.gz", "1a1483daa4b1f2062fba47feff1ecf59cddbc1ec"),
+    ARM64("greengrass-linux-aarch64-1.9.1.tar.gz", "c949da81abbf9f2be43758f4dcc529732b38f691");
 
     @Getter
     private final String DIST = "dist";

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/data/Language.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/data/Language.java
@@ -4,9 +4,9 @@ import lombok.Getter;
 import software.amazon.awssdk.services.lambda.model.Runtime;
 
 public enum Language {
-    Python(Runtime.PYTHON2_7), // Legacy, equivalent to PYTHON2_7
-    Java(Runtime.JAVA8),       // Legacy, equivalent to JAVA8
-    Node(Runtime.NODEJS8_10),  // Legacy, equivalent to NODEJS8_10
+    Python(null), // Legacy
+    Java(null),   // Legacy
+    Node(null),   // Legacy
     NODEJS6_10(Runtime.NODEJS6_10),
     NODEJS8_10(Runtime.NODEJS8_10),
     JAVA8(Runtime.JAVA8),

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/data/Language.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/data/Language.java
@@ -6,7 +6,7 @@ import software.amazon.awssdk.services.lambda.model.Runtime;
 public enum Language {
     Python(Runtime.PYTHON2_7), // Legacy, equivalent to PYTHON2_7
     Java(Runtime.JAVA8),       // Legacy, equivalent to JAVA8
-    Node(Runtime.NODEJS6_10),  // Legacy, equivalent to NODEJS6_10
+    Node(Runtime.NODEJS8_10),  // Legacy, equivalent to NODEJS8_10
     NODEJS6_10(Runtime.NODEJS6_10),
     NODEJS8_10(Runtime.NODEJS8_10),
     JAVA8(Runtime.JAVA8),

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicDeploymentHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicDeploymentHelper.java
@@ -762,7 +762,6 @@ public class BasicDeploymentHelper implements DeploymentHelper {
 
             // Describe instances retry policy
             RetryPolicy<DescribeInstancesResponse> describeInstancesRetryPolicy = new RetryPolicy<DescribeInstancesResponse>()
-                    .handle(Ec2Exception.class)
                     .handleIf(throwable -> throwable.getMessage().contains("does not exist"))
                     .withDelay(Duration.ofSeconds(5))
                     .withMaxRetries(3)
@@ -906,7 +905,6 @@ public class BasicDeploymentHelper implements DeploymentHelper {
 
         // Sometimes the security group isn't immediately visible so we need retries
         RetryPolicy<AuthorizeSecurityGroupIngressResponse> securityGroupRetryPolicy = new RetryPolicy<AuthorizeSecurityGroupIngressResponse>()
-                .handle(Ec2Exception.class)
                 .handleIf(throwable -> throwable.getMessage().contains("does not exist"))
                 .withDelay(Duration.ofSeconds(5))
                 .withMaxRetries(3)

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicFunctionHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicFunctionHelper.java
@@ -239,8 +239,8 @@ public class BasicFunctionHelper implements FunctionHelper {
             log.warn("Legacy Java function forced to Java 8");
             language = Language.JAVA8;
         } else if (language.equals(Language.Node)) {
-            log.warn("Legacy Node function forced to Node 6.10");
-            language = Language.NODEJS6_10;
+            log.warn("Legacy Node function forced to Node 8.10");
+            language = Language.NODEJS8_10;
         }
 
         functionConfBuilder.language(language);

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicLambdaHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicLambdaHelper.java
@@ -136,7 +136,6 @@ public class BasicLambdaHelper implements LambdaHelper {
 
         // Sometimes the Lambda IAM role isn't immediately visible so we need retries
         RetryPolicy<CreateFunctionResponse> lambdaIamRoleRetryPolicy = new RetryPolicy<CreateFunctionResponse>()
-                .handle(InvalidParameterValueException.class)
                 .handleIf(throwable -> throwable.getMessage().startsWith("The role defined for the function cannot be assumed by Lambda."))
                 .withDelay(Duration.ofSeconds(5))
                 .withMaxRetries(10)

--- a/src/main/resources/shell/template.sh.in
+++ b/src/main/resources/shell/template.sh.in
@@ -259,11 +259,11 @@ if [ "$UPDATE_DEPENDENCIES" = true ]; then
 
 fi
 
-EXPECTED_NODEJS_LOCATION="/usr/local/bin/nodejs6.10"
-NODEJS_6_10=`which nodejs6.10`
-NODEJS_6_10_MISSING=$?
+EXPECTED_NODEJS_LOCATION="/usr/local/bin/nodejs8.10"
+NODEJS_8_10=`which nodejs8.10`
+NODEJS_8_10_MISSING=$?
 
-if [ $NODEJS_6_10_MISSING -eq 1 ]; then
+if [ $NODEJS_8_10_MISSING -eq 1 ]; then
     # Install NodeJS
     echo "Node is missing"
     GIT=`which git`
@@ -276,9 +276,9 @@ if [ $NODEJS_6_10_MISSING -eq 1 ]; then
         pushd .
         cd n
         env "PATH=$PATH" make install
-        env "PATH=$PATH" n 6.10.3
+        env "PATH=$PATH" n 8.10.0
         NODEJS=`which node`
-        ln -s $NODEJS `dirname $NODEJS`/nodejs6.10
+        ln -s $NODEJS `dirname $NODEJS`/nodejs8.10
         popd
     fi
 fi


### PR DESCRIPTION
Updated to Greengrass 1.9.1. Some minor exception handling fixes. Set default NodeJS version to 8.10.0.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
