### PR TITLE
Updated to Device Tester 1.3.1

### DIFF
--- a/Dockerfile.run
+++ b/Dockerfile.run
@@ -10,9 +10,9 @@ RUN apt-get install -y wget libdigest-sha-perl && \
 
 # Fetch and validate Device Tester
 RUN cd / && \
-    echo "1ce00229701e84d2c1296e3b0b1bbd36e5a55521  devicetester_greengrass_linux_1.3.0.zip" > /devicetester_greengrass_linux_1.3.0.zip.sha && \
-    wget --referer=https://aws.amazon.com/greengrass/device-tester/ https://d232ctwt5kahio.cloudfront.net/greengrass/devicetester_greengrass_linux_1.3.0.zip && \
-    shasum -c /devicetester_greengrass_linux_1.3.0.zip.sha
+    echo "7df84a257824cea25e91bd910878a0a519bbaa04  devicetester_greengrass_linux_1.3.1.zip" > /devicetester_greengrass_linux_1.3.1.zip.sha && \
+    wget --referer=https://aws.amazon.com/greengrass/device-tester/ https://d232ctwt5kahio.cloudfront.net/greengrass/devicetester_greengrass_linux_1.3.1.zip && \
+    shasum -c /devicetester_greengrass_linux_1.3.1.zip.sha
 
 # Install JDK so Java functions can be built
 RUN apt-get install -y openjdk-8-jdk-headless && \

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/data/DeviceTesterLogMessageType.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/data/DeviceTesterLogMessageType.java
@@ -44,6 +44,7 @@ public enum DeviceTesterLogMessageType {
     FAIL_TO_REMOVE_GREENGRASS(string -> string.contains("Fail to remove Greengrass")),
     FAIL_TO_RESTORE_GREENGRASS(string -> string.contains("Fail to restore Greengrass")),
     COMMAND_ON_REMOTE_HOST_FAILED_TO_START(string -> string.contains("Async command on remote host failed to start with error")),
+    FAIL_TO_ADD_REMOTE_FILE_RESOURCE(string -> string.contains("failed to add remote file resource")),
     EMPTY(string -> string.isEmpty());
 
     private final Function<String, Boolean> matcher;

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicDeviceTesterHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicDeviceTesterHelper.java
@@ -62,7 +62,8 @@ public class BasicDeviceTesterHelper implements DeviceTesterHelper {
             DeviceTesterLogMessageType.CREDENTIALS_NOT_FOUND,
             DeviceTesterLogMessageType.TEST_EXITED_UNSUCCESSFULLY,
             DeviceTesterLogMessageType.FAIL_TO_REMOVE_GREENGRASS,
-            DeviceTesterLogMessageType.COMMAND_ON_REMOTE_HOST_FAILED_TO_START);
+            DeviceTesterLogMessageType.COMMAND_ON_REMOTE_HOST_FAILED_TO_START,
+            DeviceTesterLogMessageType.FAIL_TO_ADD_REMOTE_FILE_RESOURCE);
 
     @Override
     public DeviceTesterLogMessageType getLogMessageType(String logMessage) {

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGroupTestHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGroupTestHelper.java
@@ -39,9 +39,9 @@ public class BasicGroupTestHelper implements GroupTestHelper {
     private static final String TAIL_FOLLOW_COMMAND = "tail -F " + FULL_RUNTIME_LOG_PATH;
     private static final int SSH_TIMEOUT_IN_MINUTES = 45;
     private static final String DEVICE_POOL_ID = "DevicePool";
-    private static final String WINDOWS_DEVICE_TESTER_URL = "https://d232ctwt5kahio.cloudfront.net/greengrass/devicetester_greengrass_win_1.3.0.zip";
-    private static final String LINUX_DEVICE_TESTER_URL = "https://d232ctwt5kahio.cloudfront.net/greengrass/devicetester_greengrass_linux_1.3.0.zip";
-    private static final String MAC_DEVICE_TESTER_URL = "https://d232ctwt5kahio.cloudfront.net/greengrass/devicetester_greengrass_mac_1.3.0.zip";
+    private static final String WINDOWS_DEVICE_TESTER_URL = "https://d232ctwt5kahio.cloudfront.net/greengrass/devicetester_greengrass_win_1.3.1.zip";
+    private static final String LINUX_DEVICE_TESTER_URL = "https://d232ctwt5kahio.cloudfront.net/greengrass/devicetester_greengrass_linux_1.3.1.zip";
+    private static final String MAC_DEVICE_TESTER_URL = "https://d232ctwt5kahio.cloudfront.net/greengrass/devicetester_greengrass_mac_1.3.1.zip";
     private static final String SSH_CONNECTED_MESSAGE = "Connected to device under test";
     private static final String SSH_TIMED_OUT_MESSAGE = "SSH connection timed out, device under test may not be ready yet...";
     private static final String SSH_CONNECTION_REFUSED_MESSAGE = "SSH connection refused, device under test may not be ready yet...";

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGroupTestHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGroupTestHelper.java
@@ -389,6 +389,15 @@ public class BasicGroupTestHelper implements GroupTestHelper {
 
         DeviceTesterLogMessageType logMessageType = deviceTesterHelper.getLogMessageType(logMessage);
 
+        // Failure to add a remote file resource can indicate that there was a failure to sudo inside of device tester
+        if (logMessageType.equals(DeviceTesterLogMessageType.FAIL_TO_ADD_REMOTE_FILE_RESOURCE)) {
+            log.warn("The user running Device Tester on the remote host may not have permissions to sudo without a password.");
+            log.warn("To use GGP with Device Tester the user will need to be able to perform a passwordless sudo.");
+            log.warn("To enable passwordless sudo see this article: https://serverfault.com/a/160587");
+            log.warn("");
+            log.warn("If Device Tester fails after this point please enable passwordless sudo for the user and try again.");
+        }
+
         io.vavr.collection.Map<String, String> values = deviceTesterHelper.extractValuesFromLogMessage(logMessage);
 
         Option<String> optionalTestCaseId = deviceTesterHelper.getOptionalTestCaseId(values);

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicTestArgumentHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicTestArgumentHelper.java
@@ -14,7 +14,7 @@ import java.util.List;
 @Slf4j
 public class BasicTestArgumentHelper implements TestArgumentHelper {
     public static final String DTOUTPUT = "/dtoutput";
-    public static final String DT_ZIP = "/devicetester_greengrass_linux_1.3.0.zip";
+    public static final String DT_ZIP = "/devicetester_greengrass_linux_1.3.1.zip";
     @Inject
     IoHelper ioHelper;
 

--- a/src/test/java/DeviceTesterMessageParsingTest.java
+++ b/src/test/java/DeviceTesterMessageParsingTest.java
@@ -102,6 +102,8 @@ public class DeviceTesterMessageParsingTest {
 
     private static String COMMAND_ON_REMOTE_HOST_FAILED_TO_START_ERROR_1 = "[INFO] BasicGroupTestHelper: time=\"2019-04-30T17:40:38Z\" level=error msg=panic: Async command on remote host failed to start with error: EOF groupId= testCaseId=shadow_sync_test_1 deviceId=DUT executionId=c875296d-6b6d-11e9-99df-0242ac110002 suiteId=GGQ";
 
+    private static String FAIL_TO_ADD_REMOTE_FILE_RESOURCE_ERROR_1 = "[INFO] BasicGroupTestHelper: time=\"2019-06-05T18:02:47Z\" level=info msg=[Error: 101] InternalError: failed to add remote file resource: failed to copy file to target path busybox-x86_64: failed to create parent directory at path busybox-x86_64: Process exited with status 1 suiteId=GGQ groupId=version testCaseId=ggc_version_check_test_1 deviceId=DUT executionId=1e987a3f-87bc-11e9-ac9c-0242ac110002";
+
     private static List<String> CHECKING_GGC_VERSION_STRINGS = List.of(CHECKING_GGC_VERSION_1);
     private static List<String> RUNNING_STRINGS = List.of(RUNNING_1, RUNNING_2);
     private static List<String> FINISHED_STRINGS = List.of(FINISHED_1, FINISHED_2);
@@ -142,6 +144,7 @@ public class DeviceTesterMessageParsingTest {
     private static List<String> FAIL_TO_REMOVE_GREENGRASS_STRINGS = List.of(FAIL_TO_REMOVE_GREENGRASS_ERROR_1);
     private static List<String> FAIL_TO_RESTORE_GREENGRASS_STRINGS = List.of(FAIL_TO_RESTORE_GREENGRASS_ERROR_1);
     private static List<String> COMMAND_ON_REMOTE_HOST_FAILED_TO_START_STRINGS = List.of(COMMAND_ON_REMOTE_HOST_FAILED_TO_START_ERROR_1);
+    private static List<String> FAIL_TO_ADD_REMOTE_FILE_RESOURCE_STRINGS = List.of(FAIL_TO_ADD_REMOTE_FILE_RESOURCE_ERROR_1);
     private static List<String> EMPTY_STRINGS = List.of(EMPTY_1);
 
     private static List<String> ALL_STRINGS = List.of(
@@ -185,6 +188,7 @@ public class DeviceTesterMessageParsingTest {
             FAIL_TO_REMOVE_GREENGRASS_STRINGS,
             FAIL_TO_RESTORE_GREENGRASS_STRINGS,
             COMMAND_ON_REMOTE_HOST_FAILED_TO_START_STRINGS,
+            FAIL_TO_ADD_REMOTE_FILE_RESOURCE_STRINGS,
             EMPTY_STRINGS)
             .flatMap(List::toStream);
 


### PR DESCRIPTION
Fixes #106 

Adds a warning when the user may not have passwordless sudo set up on their Greengrass device under test

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
