### PR TITLE
Docker launch option overrides default function isolation mode

### DIFF
--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/docker/AbstractDockerHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/docker/AbstractDockerHelper.java
@@ -190,11 +190,6 @@ public abstract class AbstractDockerHelper implements DockerHelper {
         try (DockerClient dockerClient = getDockerClient()) {
             if (!isContainerRunning(groupName, dockerClient)) {
                 dockerClient.startContainer(containerId);
-
-                // Create the missing symlink for java8
-                String[] command = {"ln", "-sf", "/usr/bin/java", "/usr/local/bin/java8"};
-                ExecCreation execCreation = dockerClient.execCreate(containerId, command);
-                dockerClient.execStart(execCreation.id());
             } else {
                 log.info("The Docker container for this core is already running locally, the core should be redeploying now");
             }

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGroupUpdateHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGroupUpdateHelper.java
@@ -249,7 +249,7 @@ public class BasicGroupUpdateHelper implements GroupUpdateHelper {
 
         functions.add(newFunction);
 
-        String newFunctionDefinitionVersionArn = greengrassHelper.createFunctionDefinitionVersion(ImmutableSet.copyOf(functions));
+        String newFunctionDefinitionVersionArn = greengrassHelper.createFunctionDefinitionVersion(ImmutableSet.copyOf(functions), greengrassHelper.getDefaultIsolationMode(groupInformation));
 
         GroupVersion newGroupVersion = GroupVersion.builder()
                 .functionDefinitionVersionArn(newFunctionDefinitionVersionArn)
@@ -285,7 +285,7 @@ public class BasicGroupUpdateHelper implements GroupUpdateHelper {
         List<Subscription> subscriptions = removeSubscriptions(groupInformation, functionToDeleteArn);
         String newSubscriptionDefinitionVersionArn = greengrassHelper.createSubscriptionDefinitionAndVersion(subscriptions);
 
-        String newFunctionDefinitionVersionArn = greengrassHelper.createFunctionDefinitionVersion(ImmutableSet.copyOf(functions));
+        String newFunctionDefinitionVersionArn = greengrassHelper.createFunctionDefinitionVersion(ImmutableSet.copyOf(functions), greengrassHelper.getDefaultIsolationMode(groupInformation));
 
         GroupVersion newGroupVersion = GroupVersion.builder()
                 .subscriptionDefinitionVersionArn(newSubscriptionDefinitionVersionArn)

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/interfaces/helpers/FunctionHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/interfaces/helpers/FunctionHelper.java
@@ -4,6 +4,7 @@ import com.awslabs.aws.greengrass.provisioner.data.conf.DeploymentConf;
 import com.awslabs.aws.greengrass.provisioner.data.conf.FunctionConf;
 import com.awslabs.aws.greengrass.provisioner.data.functions.BuildableFunction;
 import software.amazon.awssdk.services.greengrass.model.Function;
+import software.amazon.awssdk.services.greengrass.model.FunctionIsolationMode;
 import software.amazon.awssdk.services.iam.model.Role;
 
 import java.util.List;
@@ -21,7 +22,7 @@ public interface FunctionHelper {
     String HTTPS = "https://";
     String FUNCTION_CONF = "function.conf";
 
-    List<FunctionConf> getFunctionConfObjects(Map<String, String> defaultEnvironment, DeploymentConf deploymentConf);
+    List<FunctionConf> getFunctionConfObjects(Map<String, String> defaultEnvironment, DeploymentConf deploymentConf, FunctionIsolationMode defaultFunctionIsolationMode);
 
     List<BuildableFunction> getBuildableFunctions(List<FunctionConf> functionConfs, Role lambdaRole);
 

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/interfaces/helpers/GreengrassHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/interfaces/helpers/GreengrassHelper.java
@@ -45,7 +45,7 @@ public interface GreengrassHelper {
      */
     Function buildFunctionModel(String functionArn, FunctionConfiguration lambdaFunctionConfiguration, Map<String, String> defaultEnvironment, EncodingType encodingType, boolean pinned);
 
-    String createFunctionDefinitionVersion(Set<Function> functions);
+    String createFunctionDefinitionVersion(Set<Function> functions, FunctionIsolationMode defaultFunctionIsolationMode);
 
     String createDeviceDefinitionAndVersion(String deviceDefinitionName, List<Device> devices);
 
@@ -70,6 +70,10 @@ public interface GreengrassHelper {
     GetGroupVersionResponse getLatestGroupVersion(GroupInformation groupInformation);
 
     List<Function> getFunctions(GroupInformation groupInformation);
+
+    FunctionIsolationMode getDefaultIsolationMode(GroupInformation groupInformation);
+
+    FunctionDefinitionVersion getFunctionDefinitionVersion(GroupInformation groupInformation);
 
     List<Device> getDevices(GroupInformation groupInformation);
 


### PR DESCRIPTION
This makes it easier to test with `--docker-launch`. With these changes the user doesn't have to modify their function.default.conf if they have greengrassContainer set to true but want to test with Docker.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
