### PR TITLE
Moved Greengrass container default into the fallback config

### DIFF
--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicFunctionHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicFunctionHelper.java
@@ -219,6 +219,10 @@ public class BasicFunctionHelper implements FunctionHelper {
         // Load function config file and use function.defaults.conf as the fallback for missing values
         Config config = ConfigFactory.parseFile(enabledFunctionConf);
         Config functionDefaults = ggVariables.getFunctionDefaults();
+
+        // Make sure we use the calculated default function isolation mode as the default (forced to no container when using Docker)
+        functionDefaults = functionDefaults.withValue(ggConstants.getConfGreengrassContainer(), ConfigValueFactory.fromAnyRef(FunctionIsolationMode.GREENGRASS_CONTAINER.equals(defaultFunctionIsolationMode) ? true : false));
+
         config = config.withFallback(functionDefaults);
 
         // Add the default environment values to the config so they can be used for resolution
@@ -226,9 +230,6 @@ public class BasicFunctionHelper implements FunctionHelper {
         for (Map.Entry<String, String> entry : defaultEnvironment.entrySet()) {
             config = config.withValue(entry.getKey(), ConfigValueFactory.fromAnyRef(entry.getValue()));
         }
-
-        // Make sure we use the calculated default function isolation mode (forced to no container when using Docker)
-        config = config.withValue(ggConstants.getConfGreengrassContainer(), ConfigValueFactory.fromAnyRef(FunctionIsolationMode.GREENGRASS_CONTAINER.equals(defaultFunctionIsolationMode) ? true : false));
 
         // Resolve the entire fallback config
         config = config.resolve();


### PR DESCRIPTION
This update moves the Greengrass container default into the fallback configuration so it can be overridden.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
