### PR TITLE
Fix issues with updating groups without a default container mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ build
 /foundation
 /deployments
 /credentials
+/ggds

--- a/src/integration-test/java/GreengrassBuildWithoutDockerDeploymentsIT.java
+++ b/src/integration-test/java/GreengrassBuildWithoutDockerDeploymentsIT.java
@@ -9,6 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Optional;
 
 public class GreengrassBuildWithoutDockerDeploymentsIT {
     private static Logger log = LoggerFactory.getLogger(GreengrassBuildWithoutDockerDeploymentsIT.class);
@@ -33,53 +34,49 @@ public class GreengrassBuildWithoutDockerDeploymentsIT {
     @Test
     public void shouldFailWithoutDocker() {
         expectedSystemExit.expectSystemExitWithStatus(1);
-        AwsGreengrassProvisioner.main(split(greengrassITShared.FAIL_DEPLOYMENT_COMMAND));
+        AwsGreengrassProvisioner.main(greengrassITShared.split(greengrassITShared.getFailDeploymentCommand(Optional.empty())));
     }
 
     // Test set 2: Expected success with CDD skeleton without Docker
     @Test
     public void shouldBuildJavaFunctionWithoutDocker() {
-        AwsGreengrassProvisioner.main(split(greengrassITShared.CDD_SKELETON_DEPLOYMENT_COMMAND));
+        AwsGreengrassProvisioner.main(greengrassITShared.split(greengrassITShared.getCddSkeletonDeploymentCommand(Optional.empty())));
     }
 
     // Test set 3: Expected success with Python Hello World without Docker
     @Test
     public void shouldBuildPythonFunctionWithoutDocker() {
-        AwsGreengrassProvisioner.main(split(greengrassITShared.PYTHON_HELLO_WORLD_DEPLOYMENT_COMMAND));
+        AwsGreengrassProvisioner.main(greengrassITShared.split(greengrassITShared.getPythonHelloWorldDeploymentCommand(Optional.empty())));
     }
 
     // Test set 4: Expected success with Python LiFX function (has dependencies to fetch) without Docker
     @Test
     public void shouldBuildPythonFunctionWithDependenciesWithoutDocker() {
-        AwsGreengrassProvisioner.main(split(greengrassITShared.LIFX_DEPLOYMENT_COMMAND));
+        AwsGreengrassProvisioner.main(greengrassITShared.split(greengrassITShared.getLifxDeploymentCommand(Optional.empty())));
     }
 
     // Test set 5: Expected success with Node Hello World without Docker
     @Test
     public void shouldBuildNodeFunctionWithoutDocker() {
-        AwsGreengrassProvisioner.main(split(greengrassITShared.NODE_HELLO_WORLD_DEPLOYMENT_COMMAND));
+        AwsGreengrassProvisioner.main(greengrassITShared.split(greengrassITShared.getNodeHelloWorldDeploymentCommand(Optional.empty())));
     }
 
     // Test set 6: Expected success with all three languages in one build without Docker
     @Test
     public void shouldBuildCombinedFunctionWithoutDocker() {
-        AwsGreengrassProvisioner.main(split(greengrassITShared.ALL_HELLO_WORLD_DEPLOYMENT_COMMAND));
+        AwsGreengrassProvisioner.main(greengrassITShared.split(greengrassITShared.getAllHelloWorldDeploymentCommand(Optional.empty())));
     }
 
     // Test set 7: Expected failure to launch an EC2 instance with ARM32 without Docker
     @Test
     public void shouldFailEc2LaunchWithArm32WithoutDocker() {
         expectedSystemExit.expectSystemExitWithStatus(1);
-        AwsGreengrassProvisioner.main(split(greengrassITShared.EC2_ARM32_NODE_HELLO_WORLD_DEPLOYMENT_COMMAND));
+        AwsGreengrassProvisioner.main(greengrassITShared.split(greengrassITShared.getEc2Arm32NodeHelloWorldDeploymentCommand(Optional.empty())));
     }
 
     // Test set 8: Expected success with Node Express function (has dependencies to fetch) without Docker
     @Test
     public void shouldBuildNodeFunctionWithDependenciesWithoutDocker() {
-        AwsGreengrassProvisioner.main(split(greengrassITShared.NODE_WEBSERVER_DEPLOYMENT_COMMAND));
-    }
-
-    private String[] split(String input) {
-        return input.split(" ");
+        AwsGreengrassProvisioner.main(greengrassITShared.split(greengrassITShared.getNodeWebserverDeploymentCommand(Optional.empty())));
     }
 }

--- a/src/integration-test/java/GreengrassEndToEndIT.java
+++ b/src/integration-test/java/GreengrassEndToEndIT.java
@@ -1,7 +1,10 @@
+import com.awslabs.aws.greengrass.provisioner.AwsGreengrassProvisioner;
 import com.awslabs.aws.greengrass.provisioner.implementations.helpers.BasicGGConstants;
 import com.awslabs.aws.greengrass.provisioner.implementations.helpers.BasicGGVariables;
 import com.awslabs.aws.greengrass.provisioner.implementations.helpers.BasicIoHelper;
 import com.awslabs.aws.greengrass.provisioner.implementations.helpers.BasicJsonHelper;
+import com.awslabs.aws.greengrass.provisioner.interfaces.helpers.GGConstants;
+import com.awslabs.aws.greengrass.provisioner.interfaces.helpers.GGVariables;
 import com.awslabs.aws.greengrass.provisioner.interfaces.helpers.IoHelper;
 import com.awslabs.aws.greengrass.provisioner.interfaces.helpers.JsonHelper;
 import com.awslabs.aws.iot.websockets.BasicMqttOverWebsocketsProvider;
@@ -76,25 +79,23 @@ public class GreengrassEndToEndIT {
 
         replaceStringInFunctionDefaults("greengrassContainer\\s*=\\strue", "greengrassContainer = false");
 
-        BasicGGConstants basicGGConstants = new BasicGGConstants();
-        BasicGGVariables basicGGVariables = new BasicGGVariables();
-        basicGGVariables.ggConstants = basicGGConstants;
+        GGVariables ggVariables = AwsGreengrassProvisioner.getInjector().getInstance(GGVariables.class);
         String groupName = greengrassITShared.GROUP_NAME;
-        oemArchiveName = new File(basicGGVariables.getOemArchiveName(groupName));
+        oemArchiveName = new File(ggVariables.getOemArchiveName(groupName));
         coreName = greengrassITShared.GROUP_NAME + "_Core";
 
-        ioHelper = new BasicIoHelper();
+        ioHelper = AwsGreengrassProvisioner.getInjector().getInstance(IoHelper.class);
 
         greengrassBuildWithoutDockerDeploymentsIT = new GreengrassBuildWithoutDockerDeploymentsIT();
         greengrassBuildWithoutDockerDeploymentsIT.greengrassITShared = greengrassITShared;
 
         BasicMqttOverWebsocketsProvider basicMqttOverWebsocketsProvider = new BasicMqttOverWebsocketsProvider();
-        String clientId = new BasicIoHelper().getUuid();
+        String clientId = ioHelper.getUuid();
 
         mqttClient = basicMqttOverWebsocketsProvider.getMqttClient(clientId);
         mqttClient.connect();
 
-        jsonHelper = new BasicJsonHelper();
+        jsonHelper = AwsGreengrassProvisioner.getInjector().getInstance(JsonHelper.class);
 
         flag = new AtomicBoolean(false);
 

--- a/src/integration-test/java/GreengrassEndToEndIT.java
+++ b/src/integration-test/java/GreengrassEndToEndIT.java
@@ -1,9 +1,4 @@
 import com.awslabs.aws.greengrass.provisioner.AwsGreengrassProvisioner;
-import com.awslabs.aws.greengrass.provisioner.implementations.helpers.BasicGGConstants;
-import com.awslabs.aws.greengrass.provisioner.implementations.helpers.BasicGGVariables;
-import com.awslabs.aws.greengrass.provisioner.implementations.helpers.BasicIoHelper;
-import com.awslabs.aws.greengrass.provisioner.implementations.helpers.BasicJsonHelper;
-import com.awslabs.aws.greengrass.provisioner.interfaces.helpers.GGConstants;
 import com.awslabs.aws.greengrass.provisioner.interfaces.helpers.GGVariables;
 import com.awslabs.aws.greengrass.provisioner.interfaces.helpers.IoHelper;
 import com.awslabs.aws.greengrass.provisioner.interfaces.helpers.JsonHelper;
@@ -80,9 +75,9 @@ public class GreengrassEndToEndIT {
         replaceStringInFunctionDefaults("greengrassContainer\\s*=\\strue", "greengrassContainer = false");
 
         GGVariables ggVariables = AwsGreengrassProvisioner.getInjector().getInstance(GGVariables.class);
-        String groupName = greengrassITShared.GROUP_NAME;
+        String groupName = greengrassITShared.getGroupName();
         oemArchiveName = new File(ggVariables.getOemArchiveName(groupName));
-        coreName = greengrassITShared.GROUP_NAME + "_Core";
+        coreName = greengrassITShared.getGroupName() + "_Core";
 
         ioHelper = AwsGreengrassProvisioner.getInjector().getInstance(IoHelper.class);
 

--- a/src/integration-test/java/GreengrassITShared.java
+++ b/src/integration-test/java/GreengrassITShared.java
@@ -1,13 +1,11 @@
-import com.awslabs.aws.greengrass.provisioner.implementations.helpers.BasicIoHelper;
-import com.awslabs.aws.greengrass.provisioner.implementations.helpers.BasicThreadHelper;
-import com.awslabs.aws.greengrass.provisioner.implementations.helpers.SingleThreadedExecutorHelper;
+import com.awslabs.aws.greengrass.provisioner.AwsGreengrassProvisioner;
 import com.awslabs.aws.greengrass.provisioner.interfaces.helpers.IoHelper;
 import com.awslabs.aws.greengrass.provisioner.interfaces.helpers.ThreadHelper;
 import org.apache.commons.io.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.UUID;
+import java.util.Optional;
 
 class GreengrassITShared {
     static final File NODEJS_SDK_FROM_BUILD = new File("./build/foundation/aws-greengrass-core-sdk-js.zip");
@@ -34,16 +32,7 @@ class GreengrassITShared {
     static final String NODE_HELLO_WORLD_DEPLOYMENT = "node-hello-world.conf";
     static final String ALL_HELLO_WORLD_DEPLOYMENT = "all-hello-world.conf";
     static final String FAIL_DEPLOYMENT = "FAKE";
-    final String GROUP_NAME = new BasicIoHelper().getUuid();
-    final String GROUP_OPTION = String.join(" ", "-g", GROUP_NAME);
-    final String CDD_SKELETON_DEPLOYMENT_COMMAND = String.join("", DEPLOYMENT_OPTION, CDD_SKELETON_DEPLOYMENT, " ", GROUP_OPTION);
-    final String FAIL_DEPLOYMENT_COMMAND = String.join("", DEPLOYMENT_OPTION, FAIL_DEPLOYMENT, " ", GROUP_OPTION);
-    final String PYTHON_HELLO_WORLD_DEPLOYMENT_COMMAND = String.join("", DEPLOYMENT_OPTION, PYTHON_HELLO_WORLD_DEPLOYMENT, " ", GROUP_OPTION);
-    final String LIFX_DEPLOYMENT_COMMAND = String.join("", DEPLOYMENT_OPTION, LIFX_DEPLOYMENT, " ", GROUP_OPTION);
-    final String NODE_WEBSERVER_DEPLOYMENT_COMMAND = String.join("", DEPLOYMENT_OPTION, NODE_WEBSERVER_DEPLOYMENT, " ", GROUP_OPTION);
-    final String NODE_HELLO_WORLD_DEPLOYMENT_COMMAND = String.join("", DEPLOYMENT_OPTION, NODE_HELLO_WORLD_DEPLOYMENT, " ", GROUP_OPTION);
-    final String ALL_HELLO_WORLD_DEPLOYMENT_COMMAND = String.join("", DEPLOYMENT_OPTION, ALL_HELLO_WORLD_DEPLOYMENT, " ", GROUP_OPTION);
-    final String EC2_ARM32_NODE_HELLO_WORLD_DEPLOYMENT_COMMAND = String.join("", DEPLOYMENT_OPTION, NODE_HELLO_WORLD_DEPLOYMENT, " ", GROUP_OPTION, " ", ARM32_OPTION, " ", EC2_LAUNCH_OPTION);
+    final String GROUP_NAME = AwsGreengrassProvisioner.getInjector().getInstance(IoHelper.class).getUuid();
 
     static void cleanDirectories() throws IOException {
         FileUtils.deleteDirectory(TEMP_DEPLOYMENTS);
@@ -53,12 +42,7 @@ class GreengrassITShared {
     }
 
     static ThreadHelper getThreadHelper() {
-        SingleThreadedExecutorHelper singleThreadedExecutorHelper = new SingleThreadedExecutorHelper();
-
-        BasicThreadHelper basicThreadHelper = new BasicThreadHelper();
-        basicThreadHelper.executorHelper = singleThreadedExecutorHelper;
-
-        return basicThreadHelper;
+        return AwsGreengrassProvisioner.getInjector().getInstance(ThreadHelper.class);
     }
 
     static void beforeTestSetup() throws IOException {
@@ -68,5 +52,49 @@ class GreengrassITShared {
         FileUtils.copyDirectory(GreengrassITShared.MASTER_FUNCTIONS, GreengrassITShared.TEMP_FUNCTIONS);
         FileUtils.copyDirectory(GreengrassITShared.MASTER_FOUNDATION, GreengrassITShared.TEMP_FOUNDATION);
         FileUtils.copyFile(GreengrassITShared.NODEJS_SDK_FROM_BUILD, GreengrassITShared.NODEJS_SDK_REQUIRED_FOR_TESTING);
+    }
+
+    private String getGroupOption(Optional<String> groupName) {
+        return String.join(" ", "-g", groupName.orElse(GROUP_NAME));
+    }
+
+    String getCddSkeletonDeploymentCommand(Optional<String> groupName) {
+        return String.join("", DEPLOYMENT_OPTION, CDD_SKELETON_DEPLOYMENT, " ", getGroupOption(groupName));
+    }
+
+    String getFailDeploymentCommand(Optional<String> groupName) {
+        return String.join("", DEPLOYMENT_OPTION, FAIL_DEPLOYMENT, " ", getGroupOption(groupName));
+    }
+
+    String getUpdateGroupCommand(String groupName, String functionName, String functionAlias) {
+        return String.join(" ", getGroupOption(Optional.of(groupName)), "--update-group", "--add-function", functionName, "--function-alias", functionAlias);
+    }
+
+    String getPythonHelloWorldDeploymentCommand(Optional<String> groupName) {
+        return String.join("", DEPLOYMENT_OPTION, PYTHON_HELLO_WORLD_DEPLOYMENT, " ", getGroupOption(groupName));
+    }
+
+    String getLifxDeploymentCommand(Optional<String> groupName) {
+        return String.join("", DEPLOYMENT_OPTION, LIFX_DEPLOYMENT, " ", getGroupOption(groupName));
+    }
+
+    String getNodeWebserverDeploymentCommand(Optional<String> groupName) {
+        return String.join("", DEPLOYMENT_OPTION, NODE_WEBSERVER_DEPLOYMENT, " ", getGroupOption(groupName));
+    }
+
+    String getNodeHelloWorldDeploymentCommand(Optional<String> groupName) {
+        return String.join("", DEPLOYMENT_OPTION, NODE_HELLO_WORLD_DEPLOYMENT, " ", getGroupOption(groupName));
+    }
+
+    String getAllHelloWorldDeploymentCommand(Optional<String> groupName) {
+        return String.join("", DEPLOYMENT_OPTION, ALL_HELLO_WORLD_DEPLOYMENT, " ", getGroupOption(groupName));
+    }
+
+    String getEc2Arm32NodeHelloWorldDeploymentCommand(Optional<String> groupName) {
+        return String.join("", DEPLOYMENT_OPTION, NODE_HELLO_WORLD_DEPLOYMENT, " ", getGroupOption(groupName), " ", ARM32_OPTION, " ", EC2_LAUNCH_OPTION);
+    }
+
+    String[] split(String input) {
+        return input.split(" ");
     }
 };

--- a/src/integration-test/java/GreengrassITShared.java
+++ b/src/integration-test/java/GreengrassITShared.java
@@ -32,7 +32,7 @@ class GreengrassITShared {
     static final String NODE_HELLO_WORLD_DEPLOYMENT = "node-hello-world.conf";
     static final String ALL_HELLO_WORLD_DEPLOYMENT = "all-hello-world.conf";
     static final String FAIL_DEPLOYMENT = "FAKE";
-    final String GROUP_NAME = AwsGreengrassProvisioner.getInjector().getInstance(IoHelper.class).getUuid();
+    private final String GROUP_NAME = AwsGreengrassProvisioner.getInjector().getInstance(IoHelper.class).getUuid();
 
     static void cleanDirectories() throws IOException {
         FileUtils.deleteDirectory(TEMP_DEPLOYMENTS);
@@ -54,6 +54,10 @@ class GreengrassITShared {
         FileUtils.copyFile(GreengrassITShared.NODEJS_SDK_FROM_BUILD, GreengrassITShared.NODEJS_SDK_REQUIRED_FOR_TESTING);
     }
 
+    public String getGroupName() {
+        return GROUP_NAME;
+    }
+
     private String getGroupOption(Optional<String> groupName) {
         return String.join(" ", "-g", groupName.orElse(GROUP_NAME));
     }
@@ -66,8 +70,12 @@ class GreengrassITShared {
         return String.join("", DEPLOYMENT_OPTION, FAIL_DEPLOYMENT, " ", getGroupOption(groupName));
     }
 
-    String getUpdateGroupCommand(String groupName, String functionName, String functionAlias) {
+    String getAddFunctionCommand(String groupName, String functionName, String functionAlias) {
         return String.join(" ", getGroupOption(Optional.of(groupName)), "--update-group", "--add-function", functionName, "--function-alias", functionAlias);
+    }
+
+    String getRemoveFunctionCommand(String groupName, String functionName, String functionAlias) {
+        return String.join(" ", getGroupOption(Optional.of(groupName)), "--update-group", "--remove-function", functionName, "--function-alias", functionAlias);
     }
 
     String getPythonHelloWorldDeploymentCommand(Optional<String> groupName) {

--- a/src/integration-test/java/GreengrassUpdateWithoutDockerIT.java
+++ b/src/integration-test/java/GreengrassUpdateWithoutDockerIT.java
@@ -1,0 +1,105 @@
+import com.awslabs.aws.greengrass.provisioner.AwsGreengrassProvisioner;
+import com.awslabs.aws.greengrass.provisioner.interfaces.helpers.GreengrassHelper;
+import com.awslabs.aws.greengrass.provisioner.interfaces.helpers.IoHelper;
+import org.jetbrains.annotations.NotNull;
+import org.junit.*;
+import org.junit.contrib.java.lang.system.ExpectedSystemExit;
+import org.junit.rules.ExpectedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.greengrass.model.Function;
+import software.amazon.awssdk.services.greengrass.model.GroupInformation;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+public class GreengrassUpdateWithoutDockerIT {
+    public static final String HELLO_WORLD_NODE = "HelloWorldNode";
+    private static Logger log = LoggerFactory.getLogger(GreengrassUpdateWithoutDockerIT.class);
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+    @Rule
+    public ExpectedSystemExit expectedSystemExit = ExpectedSystemExit.none();
+    GreengrassITShared greengrassITShared;
+    GreengrassHelper greengrassHelper;
+    IoHelper ioHelper;
+
+    @Before
+    public void beforeTestSetup() throws IOException {
+        greengrassITShared = new GreengrassITShared();
+        GreengrassITShared.beforeTestSetup();
+
+        greengrassHelper = AwsGreengrassProvisioner.getInjector().getInstance(GreengrassHelper.class);
+        ioHelper = AwsGreengrassProvisioner.getInjector().getInstance(IoHelper.class);
+    }
+
+    @After
+    public void afterTestTeardown() throws IOException {
+        GreengrassITShared.cleanDirectories();
+    }
+
+    // Test set 1: Build a group with Python Hello World, build another group with Node Hello World, add Node Hello World to first group
+    @Test
+    public void shouldAddNodeFunctionToGroup() {
+        // Create two groups with different names so we can do the update later
+        Optional<String> optionalGroup1Name = Optional.of(ioHelper.getUuid());
+        Optional<String> optionalGroup2Name = Optional.of(ioHelper.getUuid());
+
+        AwsGreengrassProvisioner.main(greengrassITShared.split(greengrassITShared.getPythonHelloWorldDeploymentCommand(optionalGroup1Name)));
+        AwsGreengrassProvisioner.main(greengrassITShared.split(greengrassITShared.getNodeHelloWorldDeploymentCommand(optionalGroup2Name)));
+
+        String group1Name = optionalGroup1Name.get();
+        String group2Name = optionalGroup2Name.get();
+
+        // Get the information for group 2 so we can pull the Hello World function out of it
+        GroupInformation group2Information = greengrassHelper.getGroupInformation(group2Name)
+                .orElseThrow(() -> new RuntimeException("Group 2 information not present"));
+
+        // Pull the Hello World function out of the group
+        Optional<Function> optionalGroup2HelloWorldNodeFunction = getFunctionFromGroupInformation(group2Information, HELLO_WORLD_NODE);
+
+        // Make sure the function is present
+        Assert.assertTrue(optionalGroup2HelloWorldNodeFunction.isPresent());
+
+        // Get the function information, extract the short name, and create a new alias
+        Function helloWorldNodeFunction = optionalGroup2HelloWorldNodeFunction.get();
+        String helloWorldNodeFunctionName = extractFunctionName(helloWorldNodeFunction);
+        String functionAlias = ioHelper.getUuid();
+
+        // Make sure the function isn't present in group 1 before the update
+        GroupInformation group1InformationBeforeUpdate = greengrassHelper.getGroupInformation(group1Name)
+                .orElseThrow(() -> new RuntimeException("Group 1 information not present before update"));
+
+        Optional<Function> optionalGroup1HelloWorldNodeFunctionBeforeUpdate = getFunctionFromGroupInformation(group1InformationBeforeUpdate, HELLO_WORLD_NODE);
+
+        Assert.assertFalse(optionalGroup1HelloWorldNodeFunctionBeforeUpdate.isPresent());
+
+        // Update group 1 with the function
+        AwsGreengrassProvisioner.main(greengrassITShared.split(greengrassITShared.getUpdateGroupCommand(group1Name, helloWorldNodeFunctionName, functionAlias)));
+
+        // Make sure the function is present in group 1 after the update
+        GroupInformation group1InformationAfterUpdate = greengrassHelper.getGroupInformation(group1Name)
+                .orElseThrow(() -> new RuntimeException("Group 1 information not present after update"));
+
+        Optional<Function> optionalGroup1HelloWorldNodeFunctionAfterUpdate = getFunctionFromGroupInformation(group1InformationAfterUpdate, HELLO_WORLD_NODE);
+
+        Assert.assertTrue(optionalGroup1HelloWorldNodeFunctionAfterUpdate.isPresent());
+    }
+
+    @NotNull
+    private Optional<Function> getFunctionFromGroupInformation(GroupInformation groupInformation, String functionName) {
+        List<Function> group2Functions = greengrassHelper.getFunctions(groupInformation);
+
+        return group2Functions.stream()
+                .filter(function -> function.functionArn().contains(functionName))
+                .findFirst();
+    }
+
+    private String extractFunctionName(Function helloWorldNodeFunction) {
+        String returnValue = helloWorldNodeFunction.functionArn().replaceAll("^.*:function:", "");
+        returnValue = returnValue.replaceAll(":.*$", "");
+
+        return returnValue;
+    }
+}

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/AwsGreengrassProvisioner.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/AwsGreengrassProvisioner.java
@@ -69,7 +69,7 @@ public class AwsGreengrassProvisioner implements Runnable {
         return getInjector().getInstance(AwsGreengrassProvisioner.class);
     }
 
-    private static Injector getInjector() {
+    public static Injector getInjector() {
         if (!optionalInjector.isPresent()) {
             optionalInjector = Optional.of(Guice.createInjector(new AwsGreengrassProvisionerModule()));
         }

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGreengrassHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGreengrassHelper.java
@@ -984,7 +984,16 @@ public class BasicGreengrassHelper implements GreengrassHelper {
     public FunctionIsolationMode getDefaultIsolationMode(GroupInformation groupInformation) {
         FunctionDefinitionVersion functionDefinition = getFunctionDefinitionVersion(groupInformation);
 
-        return functionDefinition.defaultConfig().execution().isolationMode();
+        Optional<FunctionIsolationMode> optionalFunctionIsolationMode = Optional.ofNullable(functionDefinition.defaultConfig())
+                .map(FunctionDefaultConfig::execution)
+                .map(FunctionDefaultExecutionConfig::isolationMode);
+
+        if (!optionalFunctionIsolationMode.isPresent()) {
+            log.warn("Default function isolation mode was not present, defaulting to Greengrass container");
+            return FunctionIsolationMode.GREENGRASS_CONTAINER;
+        }
+
+        return optionalFunctionIsolationMode.get();
     }
 
     @Override

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGreengrassHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGreengrassHelper.java
@@ -340,16 +340,18 @@ public class BasicGreengrassHelper implements GreengrassHelper {
         if (defaultFunctionIsolationMode.equals(FunctionIsolationMode.NO_CONTAINER)) {
             log.warn("Default isolation mode is no container");
 
-            functionDefinitionVersionBuilder.defaultConfig(
-                    FunctionDefaultConfig.builder()
-                            .execution(FunctionDefaultExecutionConfig.builder()
-                                    .isolationMode(FunctionIsolationMode.NO_CONTAINER)
-                                    .build())
-                            .build());
-
             // Scrub all functions without an isolation mode specified
             functionsToScrubBuilder.addAll(functionsWithoutIsolationModeSpecified);
+        } else {
+            log.info("Default isolation mode is Greengrass container");
         }
+
+        functionDefinitionVersionBuilder.defaultConfig(
+                FunctionDefaultConfig.builder()
+                        .execution(FunctionDefaultExecutionConfig.builder()
+                                .isolationMode(defaultFunctionIsolationMode)
+                                .build())
+                        .build());
 
         // Get the list of functions we need to scrub
         Set<Function> functionsToScrub = functionsToScrubBuilder.build();


### PR DESCRIPTION
Fixes #156 

- Sets default isolation mode to no container or Greengrass container on each deploy
- Uses Greengrass container as the default isolation mode if it is not present

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
