### PR TITLE
Set core shadow sync to true by default

### DIFF
--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/data/KeysAndCertificate.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/data/KeysAndCertificate.java
@@ -9,7 +9,7 @@ import software.amazon.awssdk.services.iot.model.KeyPair;
 @Value.Immutable
 public abstract class KeysAndCertificate {
     public static KeysAndCertificate from(CreateKeysAndCertificateResponse createKeysAndCertificateResponse) {
-        return ImmutableKeysAndCertificate.builder()
+        return com.awslabs.aws.greengrass.provisioner.data.ImmutableKeysAndCertificate.builder()
                 .certificateArn(createKeysAndCertificateResponse.certificateArn())
                 .certificateId(createKeysAndCertificateResponse.certificateId())
                 .certificatePem(createKeysAndCertificateResponse.certificatePem())

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicDeploymentHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicDeploymentHelper.java
@@ -3,6 +3,8 @@ package com.awslabs.aws.greengrass.provisioner.implementations.helpers;
 import com.awslabs.aws.greengrass.provisioner.data.*;
 import com.awslabs.aws.greengrass.provisioner.data.arguments.DeploymentArguments;
 import com.awslabs.aws.greengrass.provisioner.data.conf.*;
+import com.awslabs.aws.greengrass.provisioner.data.conf.ImmutableDeploymentConf;
+import com.awslabs.aws.greengrass.provisioner.data.conf.ModifiableFunctionConf;
 import com.awslabs.aws.greengrass.provisioner.data.functions.BuildableFunction;
 import com.awslabs.aws.greengrass.provisioner.data.functions.BuildableJavaMavenFunction;
 import com.awslabs.aws.greengrass.provisioner.docker.BasicProgressHandler;

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicFunctionHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicFunctionHelper.java
@@ -1,11 +1,16 @@
 package com.awslabs.aws.greengrass.provisioner.implementations.helpers;
 
 import com.awslabs.aws.greengrass.provisioner.data.*;
+import com.awslabs.aws.greengrass.provisioner.data.ImmutableLambdaFunctionArnInfo;
+import com.awslabs.aws.greengrass.provisioner.data.ImmutableLambdaFunctionArnInfoAndFunctionConf;
 import com.awslabs.aws.greengrass.provisioner.data.conf.DeploymentConf;
 import com.awslabs.aws.greengrass.provisioner.data.conf.FunctionConf;
 import com.awslabs.aws.greengrass.provisioner.data.conf.ModifiableFunctionConf;
 import com.awslabs.aws.greengrass.provisioner.data.functions.*;
 import com.awslabs.aws.greengrass.provisioner.data.resources.*;
+import com.awslabs.aws.greengrass.provisioner.data.resources.ImmutableLocalS3Resource;
+import com.awslabs.aws.greengrass.provisioner.data.resources.ImmutableLocalSageMakerResource;
+import com.awslabs.aws.greengrass.provisioner.data.resources.ImmutableLocalVolumeResource;
 import com.awslabs.aws.greengrass.provisioner.interfaces.builders.GradleBuilder;
 import com.awslabs.aws.greengrass.provisioner.interfaces.builders.MavenBuilder;
 import com.awslabs.aws.greengrass.provisioner.interfaces.helpers.*;

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGreengrassHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGreengrassHelper.java
@@ -186,7 +186,7 @@ public class BasicGreengrassHelper implements GreengrassHelper {
         Core core = Core.builder()
                 .certificateArn(coreCertificateArn)
                 .id(uuid)
-                .syncShadow(false)
+                .syncShadow(true)
                 .thingArn(coreThingArn)
                 .build();
 

--- a/src/test/java/com/awslabs/aws/greengrass/provisioner/data/KeysAndCertificateSerializationTests.java
+++ b/src/test/java/com/awslabs/aws/greengrass/provisioner/data/KeysAndCertificateSerializationTests.java
@@ -21,7 +21,7 @@ public class KeysAndCertificateSerializationTests {
                 .privateKey("privateKey123")
                 .publicKey("publicKey123")
                 .build();
-        keysAndCertificate = ImmutableKeysAndCertificate.builder()
+        keysAndCertificate = com.awslabs.aws.greengrass.provisioner.data.ImmutableKeysAndCertificate.builder()
                 .certificateArn("certificateArn123")
                 .certificateId("certificateId123")
                 .certificatePem("certificatePem123")


### PR DESCRIPTION
Fixes #177 by changing the default to have the core's shadow synced. This does not add a feature to configure whether or not it is synced.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
