### PR TITLE
Added Python 2 and 3 builders

### DIFF
--- a/Dockerfile.run
+++ b/Dockerfile.run
@@ -18,8 +18,12 @@ RUN cd / && \
 RUN apt-get install -y openjdk-8-jdk-headless && \
     apt-get -y clean
 
-# Install pip so Python functions can be built
+# Install pip so Python 2 functions can be built
 RUN apt-get install -y python-pip && \
+    apt-get -y clean
+
+# Install pip so Python 3 functions can be built
+RUN apt-get install -y python3-pip && \
     apt-get -y clean
 
 # Install NodeJS and npm so Node functions can be built

--- a/src/integration-test/java/GreengrassBuildWithDockerDeploymentsIT.java
+++ b/src/integration-test/java/GreengrassBuildWithDockerDeploymentsIT.java
@@ -157,10 +157,10 @@ public class GreengrassBuildWithDockerDeploymentsIT {
         runContainer(greengrassITShared.getCddSkeletonDeploymentCommand(Optional.empty()), equalTo(0));
     }
 
-    // Test set 3: Expected success with Python Hello World with Docker
+    // Test set 3: Expected success with Python 2 Hello World with Docker
     @Test
-    public void shouldBuildPythonFunctionWithDocker() {
-        runContainer(greengrassITShared.getPythonHelloWorldDeploymentCommand(Optional.empty()), equalTo(0));
+    public void shouldBuildPython2FunctionWithDocker() {
+        runContainer(greengrassITShared.getPython2HelloWorldDeploymentCommand(Optional.empty()), equalTo(0));
     }
 
     // Test set 4: Expected success with Python LiFX function (has dependencies to fetch) with Docker
@@ -191,6 +191,12 @@ public class GreengrassBuildWithDockerDeploymentsIT {
     @Test
     public void shouldBuildNodeFunctionWithDependenciesWithDocker() {
         runContainer(greengrassITShared.getNodeWebserverDeploymentCommand(Optional.empty()), equalTo(0));
+    }
+
+    // Test set 9: Expected success with Python 3 Hello World with Docker
+    @Test
+    public void shouldBuildPython3FunctionWithDocker() {
+        runContainer(greengrassITShared.getPython3HelloWorldDeploymentCommand(Optional.empty()), equalTo(0));
     }
 
     private void runContainer(String nodeHelloWorldDeploymentCommand, Matcher<Integer> integerMatcher) {

--- a/src/integration-test/java/GreengrassBuildWithoutDockerDeploymentsIT.java
+++ b/src/integration-test/java/GreengrassBuildWithoutDockerDeploymentsIT.java
@@ -43,10 +43,10 @@ public class GreengrassBuildWithoutDockerDeploymentsIT {
         AwsGreengrassProvisioner.main(greengrassITShared.split(greengrassITShared.getCddSkeletonDeploymentCommand(Optional.empty())));
     }
 
-    // Test set 3: Expected success with Python Hello World without Docker
+    // Test set 3: Expected success with Python 2 Hello World without Docker
     @Test
-    public void shouldBuildPythonFunctionWithoutDocker() {
-        AwsGreengrassProvisioner.main(greengrassITShared.split(greengrassITShared.getPythonHelloWorldDeploymentCommand(Optional.empty())));
+    public void shouldBuildPython2FunctionWithoutDocker() {
+        AwsGreengrassProvisioner.main(greengrassITShared.split(greengrassITShared.getPython2HelloWorldDeploymentCommand(Optional.empty())));
     }
 
     // Test set 4: Expected success with Python LiFX function (has dependencies to fetch) without Docker
@@ -84,5 +84,11 @@ public class GreengrassBuildWithoutDockerDeploymentsIT {
     @Test
     public void shouldBuildX86_64SampleCWithoutDocker() {
         AwsGreengrassProvisioner.main(greengrassITShared.split(greengrassITShared.getX86_64SampleCDeploymentCommand(Optional.empty())));
+    }
+
+    // Test set 10: Expected success with Python 3 Hello World without Docker
+    @Test
+    public void shouldBuildPython3FunctionWithoutDocker() {
+        AwsGreengrassProvisioner.main(greengrassITShared.split(greengrassITShared.getPython3HelloWorldDeploymentCommand(Optional.empty())));
     }
 }

--- a/src/integration-test/java/GreengrassITShared.java
+++ b/src/integration-test/java/GreengrassITShared.java
@@ -26,7 +26,8 @@ class GreengrassITShared {
     static final String ARM32_OPTION = "-a ARM32";
     static final String EC2_LAUNCH_OPTION = "--ec2-launch";
     static final String CDD_SKELETON_DEPLOYMENT = "cdd-skeleton.conf";
-    static final String PYTHON_HELLO_WORLD_DEPLOYMENT = "python-hello-world.conf";
+    static final String PYTHON2_HELLO_WORLD_DEPLOYMENT = "python2-hello-world.conf";
+    static final String PYTHON3_HELLO_WORLD_DEPLOYMENT = "python3-hello-world.conf";
     static final String LIFX_DEPLOYMENT = "lifx.conf";
     static final String NODE_WEBSERVER_DEPLOYMENT = "web-server-node.conf";
     static final String NODE_HELLO_WORLD_DEPLOYMENT = "node-hello-world.conf";
@@ -79,8 +80,12 @@ class GreengrassITShared {
         return String.join(" ", getGroupOption(Optional.of(groupName)), "--update-group", "--remove-function", functionName, "--function-alias", functionAlias);
     }
 
-    String getPythonHelloWorldDeploymentCommand(Optional<String> groupName) {
-        return String.join("", DEPLOYMENT_OPTION, PYTHON_HELLO_WORLD_DEPLOYMENT, " ", getGroupOption(groupName));
+    String getPython2HelloWorldDeploymentCommand(Optional<String> groupName) {
+        return String.join("", DEPLOYMENT_OPTION, PYTHON2_HELLO_WORLD_DEPLOYMENT, " ", getGroupOption(groupName));
+    }
+
+    String getPython3HelloWorldDeploymentCommand(Optional<String> groupName) {
+        return String.join("", DEPLOYMENT_OPTION, PYTHON3_HELLO_WORLD_DEPLOYMENT, " ", getGroupOption(groupName));
     }
 
     String getLifxDeploymentCommand(Optional<String> groupName) {

--- a/src/integration-test/java/GreengrassUpdateWithoutDockerIT.java
+++ b/src/integration-test/java/GreengrassUpdateWithoutDockerIT.java
@@ -16,7 +16,8 @@ import java.util.Optional;
 
 public class GreengrassUpdateWithoutDockerIT {
     private static final String HELLO_WORLD_NODE = "HelloWorldNode";
-    private static final String HELLO_WORLD_PYTHON = "HelloWorldPython";
+    private static final String HELLO_WORLD_PYTHON2 = "HelloWorldPython2";
+    private static final String HELLO_WORLD_PYTHON3 = "HelloWorldPython3";
     private static Logger log = LoggerFactory.getLogger(GreengrassUpdateWithoutDockerIT.class);
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
@@ -40,14 +41,14 @@ public class GreengrassUpdateWithoutDockerIT {
         GreengrassITShared.cleanDirectories();
     }
 
-    // Test set 1: Build a group with Python Hello World, build another group with Node Hello World, add Node Hello World to first group
+    // Test set 1: Build a group with Python 2 Hello World, build another group with Node Hello World, add Node Hello World to first group
     @Test
     public void shouldAddNodeFunctionToGroup() {
         // Create two groups with different names so we can do the update later
         Optional<String> optionalGroup1Name = Optional.of(ioHelper.getUuid());
         Optional<String> optionalGroup2Name = Optional.of(ioHelper.getUuid());
 
-        AwsGreengrassProvisioner.main(greengrassITShared.split(greengrassITShared.getPythonHelloWorldDeploymentCommand(optionalGroup1Name)));
+        AwsGreengrassProvisioner.main(greengrassITShared.split(greengrassITShared.getPython2HelloWorldDeploymentCommand(optionalGroup1Name)));
         AwsGreengrassProvisioner.main(greengrassITShared.split(greengrassITShared.getNodeHelloWorldDeploymentCommand(optionalGroup2Name)));
 
         String group1Name = optionalGroup1Name.get();
@@ -88,13 +89,13 @@ public class GreengrassUpdateWithoutDockerIT {
         Assert.assertTrue(optionalGroup1HelloWorldNodeFunctionAfterUpdate.isPresent());
     }
 
-    // Test set 2: Build a group with Python Hello World, remove the Python Hello World function
+    // Test set 2: Build a group with Python 2 Hello World, remove the Python 2 Hello World function
     @Test
     public void shouldRemovePythonFunctionFromGroup() {
         // Create one group with a known name
         Optional<String> optionalGroupName = Optional.of(ioHelper.getUuid());
 
-        AwsGreengrassProvisioner.main(greengrassITShared.split(greengrassITShared.getPythonHelloWorldDeploymentCommand(optionalGroupName)));
+        AwsGreengrassProvisioner.main(greengrassITShared.split(greengrassITShared.getPython2HelloWorldDeploymentCommand(optionalGroupName)));
 
         String groupName = optionalGroupName.get();
 
@@ -103,7 +104,7 @@ public class GreengrassUpdateWithoutDockerIT {
                 .orElseThrow(() -> new RuntimeException("Group information not present"));
 
         // Pull the Hello World function out of the group
-        Optional<Function> optionalGroupHelloWorldPythonFunction = getFunctionFromGroupInformation(groupInformation, HELLO_WORLD_PYTHON);
+        Optional<Function> optionalGroupHelloWorldPythonFunction = getFunctionFromGroupInformation(groupInformation, HELLO_WORLD_PYTHON2);
 
         // Make sure the function is present
         Assert.assertTrue(optionalGroupHelloWorldPythonFunction.isPresent());
@@ -120,7 +121,7 @@ public class GreengrassUpdateWithoutDockerIT {
         GroupInformation groupInformationAfterUpdate = greengrassHelper.getGroupInformation(groupName)
                 .orElseThrow(() -> new RuntimeException("Group information not present after update"));
 
-        Optional<Function> optionalGroupHelloWorldPythonFunctionAfterUpdate = getFunctionFromGroupInformation(groupInformationAfterUpdate, HELLO_WORLD_PYTHON);
+        Optional<Function> optionalGroupHelloWorldPythonFunctionAfterUpdate = getFunctionFromGroupInformation(groupInformationAfterUpdate, HELLO_WORLD_PYTHON2);
 
         Assert.assertFalse(optionalGroupHelloWorldPythonFunctionAfterUpdate.isPresent());
     }

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/AwsGreengrassProvisionerModule.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/AwsGreengrassProvisionerModule.java
@@ -55,8 +55,9 @@ public class AwsGreengrassProvisionerModule extends AbstractModule {
         bind(ConfigFileHelper.class).to(BasicConfigFileHelper.class);
         bind(GreengrassHelper.class).to(BasicGreengrassHelper.class);
         bind(IamHelper.class).to(BasicIamHelper.class);
+        bind(Python2Builder.class).to(BasicPython2Builder.class);
+        bind(Python3Builder.class).to(BasicPython3Builder.class);
         bind(LambdaHelper.class).to(BasicLambdaHelper.class);
-        bind(PythonBuilder.class).to(BasicPythonBuilder.class);
         bind(NodeBuilder.class).to(BasicNodeBuilder.class);
         bind(ExecutableBuilder.class).to(BasicExecutableBuilder.class);
         bind(ProcessHelper.class).to(BasicProcessHelper.class);

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/data/functions/BuildablePython2Function.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/data/functions/BuildablePython2Function.java
@@ -1,0 +1,10 @@
+package com.awslabs.aws.greengrass.provisioner.data.functions;
+
+import com.awslabs.aws.greengrass.provisioner.data.conf.ModifiableFunctionConf;
+import software.amazon.awssdk.services.iam.model.Role;
+
+public class BuildablePython2Function extends BuildableFunction {
+    public BuildablePython2Function(ModifiableFunctionConf functionConf, Role lambdaRole) {
+        super(functionConf, lambdaRole);
+    }
+}

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/data/functions/BuildablePython3Function.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/data/functions/BuildablePython3Function.java
@@ -3,8 +3,8 @@ package com.awslabs.aws.greengrass.provisioner.data.functions;
 import com.awslabs.aws.greengrass.provisioner.data.conf.ModifiableFunctionConf;
 import software.amazon.awssdk.services.iam.model.Role;
 
-public class BuildablePythonFunction extends BuildableFunction {
-    public BuildablePythonFunction(ModifiableFunctionConf functionConf, Role lambdaRole) {
+public class BuildablePython3Function extends BuildableFunction {
+    public BuildablePython3Function(ModifiableFunctionConf functionConf, Role lambdaRole) {
         super(functionConf, lambdaRole);
     }
 }

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/builders/BasicPython2Builder.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/builders/BasicPython2Builder.java
@@ -1,0 +1,9 @@
+package com.awslabs.aws.greengrass.provisioner.implementations.builders;
+
+import com.awslabs.aws.greengrass.provisioner.interfaces.builders.Python2Builder;
+
+public class BasicPython2Builder extends BasicPythonBuilder implements Python2Builder {
+    public String getPip() {
+        return "pip";
+    }
+}

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/builders/BasicPython3Builder.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/builders/BasicPython3Builder.java
@@ -1,0 +1,9 @@
+package com.awslabs.aws.greengrass.provisioner.implementations.builders;
+
+import com.awslabs.aws.greengrass.provisioner.interfaces.builders.Python3Builder;
+
+public class BasicPython3Builder extends BasicPythonBuilder implements Python3Builder {
+    public String getPip() {
+        return "pip3";
+    }
+}

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/builders/BasicPythonBuilder.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/builders/BasicPythonBuilder.java
@@ -24,8 +24,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-public class BasicPythonBuilder implements PythonBuilder {
-    private static final String PIP = "pip";
+public abstract class BasicPythonBuilder implements PythonBuilder {
     private static final String REQUIREMENTS_TXT = "requirements.txt";
     private final Logger log = LoggerFactory.getLogger(BasicPythonBuilder.class);
     private final String DIST_INFO = ".dist-info";
@@ -113,7 +112,7 @@ public class BasicPythonBuilder implements PythonBuilder {
         loggingHelper.logInfoWithName(log, functionConf.getFunctionName(), "Retrieving Python dependencies");
 
         List<String> programAndArguments = new ArrayList<>();
-        programAndArguments.add(PIP);
+        programAndArguments.add(getPip());
         programAndArguments.add("install");
         programAndArguments.add("--upgrade");
         programAndArguments.add("-r");
@@ -147,9 +146,11 @@ public class BasicPythonBuilder implements PythonBuilder {
         }
     }
 
+    protected abstract String getPip();
+
     private boolean isCorrectPipVersion() {
         List<String> programAndArguments = new ArrayList<>();
-        programAndArguments.add(PIP);
+        programAndArguments.add(getPip());
         programAndArguments.add("--version");
 
         ProcessBuilder processBuilder = processHelper.getProcessBuilder(programAndArguments);

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicLambdaHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicLambdaHelper.java
@@ -25,8 +25,8 @@ import java.time.Duration;
 import java.util.Optional;
 
 public class BasicLambdaHelper implements LambdaHelper {
-    public static final String ARN_AWS_GREENGRASS_RUNTIME_FUNCTION_EXECUTABLE = "arn:aws:greengrass:::runtime/function/executable";
-    public static final String ZIP_ARCHIVE_FOR_EXECUTABLE_NATIVE_FUNCTION_NOT_PRESENT = "ZIP archive for executable/native function not present ";
+    private static final String ARN_AWS_GREENGRASS_RUNTIME_FUNCTION_EXECUTABLE = "arn:aws:greengrass:::runtime/function/executable";
+    private static final String ZIP_ARCHIVE_FOR_EXECUTABLE_NATIVE_FUNCTION_NOT_PRESENT = "ZIP archive for executable/native function not present ";
     private final Logger log = LoggerFactory.getLogger(BasicLambdaHelper.class);
     @Inject
     LambdaClient lambdaClient;
@@ -37,7 +37,9 @@ public class BasicLambdaHelper implements LambdaHelper {
     @Inject
     GradleBuilder gradleBuilder;
     @Inject
-    PythonBuilder pythonBuilder;
+    Python2Builder python2Builder;
+    @Inject
+    Python3Builder python3Builder;
     @Inject
     NodeBuilder nodeBuilder;
     @Inject
@@ -100,17 +102,33 @@ public class BasicLambdaHelper implements LambdaHelper {
     }
 
     @Override
-    public LambdaFunctionArnInfo buildAndCreatePythonFunctionIfNecessary(FunctionConf functionConf, Role role) {
-        Optional<String> error = pythonBuilder.verifyHandlerExists(functionConf);
+    public LambdaFunctionArnInfo buildAndCreatePython2FunctionIfNecessary(FunctionConf functionConf, Role role) {
+        Optional<String> error = python2Builder.verifyHandlerExists(functionConf);
 
         if (error.isPresent()) {
             return ImmutableLambdaFunctionArnInfo.builder()
                     .error(error).build();
         }
 
-        pythonBuilder.buildFunctionIfNecessary(functionConf);
+        python2Builder.buildFunctionIfNecessary(functionConf);
 
-        String zipFilePath = pythonBuilder.getArchivePath(functionConf);
+        String zipFilePath = python2Builder.getArchivePath(functionConf);
+
+        return createFunctionIfNecessary(functionConf, role, zipFilePath);
+    }
+
+    @Override
+    public LambdaFunctionArnInfo buildAndCreatePython3FunctionIfNecessary(FunctionConf functionConf, Role role) {
+        Optional<String> error = python3Builder.verifyHandlerExists(functionConf);
+
+        if (error.isPresent()) {
+            return ImmutableLambdaFunctionArnInfo.builder()
+                    .error(error).build();
+        }
+
+        python3Builder.buildFunctionIfNecessary(functionConf);
+
+        String zipFilePath = python3Builder.getArchivePath(functionConf);
 
         return createFunctionIfNecessary(functionConf, role, zipFilePath);
     }

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/interfaces/builders/Python2Builder.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/interfaces/builders/Python2Builder.java
@@ -1,0 +1,4 @@
+package com.awslabs.aws.greengrass.provisioner.interfaces.builders;
+
+public interface Python2Builder extends ScriptingFunctionBuilder {
+}

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/interfaces/builders/Python3Builder.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/interfaces/builders/Python3Builder.java
@@ -1,0 +1,4 @@
+package com.awslabs.aws.greengrass.provisioner.interfaces.builders;
+
+public interface Python3Builder extends ScriptingFunctionBuilder {
+}

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/interfaces/helpers/FunctionHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/interfaces/helpers/FunctionHelper.java
@@ -26,7 +26,9 @@ public interface FunctionHelper {
 
     List<BuildableFunction> getBuildableFunctions(List<ModifiableFunctionConf> functionConfs, Role lambdaRole);
 
-    Predicate<ModifiableFunctionConf> getPythonPredicate();
+    Predicate<ModifiableFunctionConf> getPython2Predicate();
+
+    Predicate<ModifiableFunctionConf> getPython3Predicate();
 
     Predicate<ModifiableFunctionConf> getNodePredicate();
 

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/interfaces/helpers/LambdaHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/interfaces/helpers/LambdaHelper.java
@@ -13,7 +13,9 @@ public interface LambdaHelper {
 
     LambdaFunctionArnInfo buildAndCreateJavaFunctionIfNecessary(FunctionConf functionConf, Role role);
 
-    LambdaFunctionArnInfo buildAndCreatePythonFunctionIfNecessary(FunctionConf functionConf, Role role);
+    LambdaFunctionArnInfo buildAndCreatePython2FunctionIfNecessary(FunctionConf functionConf, Role role);
+
+    LambdaFunctionArnInfo buildAndCreatePython3FunctionIfNecessary(FunctionConf functionConf, Role role);
 
     LambdaFunctionArnInfo buildAndCreateNodeFunctionIfNecessary(FunctionConf functionConf, Role role);
 

--- a/src/main/resources/shell/template.sh.in
+++ b/src/main/resources/shell/template.sh.in
@@ -219,6 +219,16 @@ if [ "$UPDATE_DEPENDENCIES" = true ]; then
         PIP_PACKAGES=
     fi
 
+    PIP3=`which pip3`
+    PIP3_MISSING=$?
+
+    if [ $PIP3_MISSING -eq 1 ]; then
+        # Only install this stuff if pip is missing
+        PIP3_PACKAGES="python3.7 python3-pip python3-setuptools"
+    else
+        PIP3_PACKAGES=
+    fi
+
     COUNTER=0
 
     until $INSTALLER update -y || (( COUNTER++ >= 3 ));
@@ -233,7 +243,7 @@ if [ "$UPDATE_DEPENDENCIES" = true ]; then
       exit 1
     fi
 
-    $INSTALLER install -y sqlite3 bzip2 $PIP_PACKAGES git
+    $INSTALLER install -y sqlite3 bzip2 $PIP_PACKAGES $PIP3_PACKAGES git
     $INSTALLER install -y $INSTALLER_SPECIFIC_PACKAGES
     $INSTALLER install -y mosh
 


### PR DESCRIPTION
Fixes #186 

Python 2 and Python 3 builds now work even when pip3 dependencies are required.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
