### PR TITLE
Fix a bug top-level directories disappeared during packaging files of python lambda

### DIFF
--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/builders/BasicPythonBuilder.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/builders/BasicPythonBuilder.java
@@ -48,7 +48,8 @@ public abstract class BasicPythonBuilder implements PythonBuilder {
         File file = path.toFile();
 
         if (file.isDirectory()) {
-            Try.run(() -> FileUtils.copyDirectory(file, destination)).get();
+            File dirDestination = new File(String.join("/", destination.getPath(), file.getName()));
+            Try.run(() -> FileUtils.copyDirectory(file, dirDestination)).get();
         } else {
             Try.run(() -> FileUtils.copyToDirectory(file, destination)).get();
         }


### PR DESCRIPTION
*Fixes: https://github.com/awslabs/aws-greengrass-provisioner/issues/450*

*Description of changes:*
This PR copies top level directories of python lambda function correctly during creating lambda package in the local PC using GGP. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
