### PR TITLE
Allow reuse of volume resources across multiple Greengrass Lambda functions

### DIFF
--- a/src/integration-test/java/GreengrassBuildWithDockerDeploymentsIT.java
+++ b/src/integration-test/java/GreengrassBuildWithDockerDeploymentsIT.java
@@ -4,7 +4,6 @@ import com.awslabs.aws.greengrass.provisioner.interfaces.helpers.IoHelper;
 import com.awslabs.aws.greengrass.provisioner.interfaces.helpers.ProcessHelper;
 import org.hamcrest.Matcher;
 import org.hamcrest.MatcherAssert;
-import org.jetbrains.annotations.NotNull;
 import org.junit.*;
 import org.junit.contrib.java.lang.system.ExpectedSystemExit;
 import org.slf4j.Logger;
@@ -25,6 +24,7 @@ import static org.hamcrest.CoreMatchers.*;
 
 // NOTE: Ignoring these tests since currently testcontainers throws a java.lang.OutOfMemoryError on every test
 public class GreengrassBuildWithDockerDeploymentsIT {
+    public static final String DOT_AWS = ".aws";
     private static final Matcher<Integer> EXIT_CODE_IS_ZERO = equalTo(0);
     private static final Matcher<Integer> EXIT_CODE_IS_NOT_ZERO = not(EXIT_CODE_IS_ZERO);
     private static Logger log = LoggerFactory.getLogger(GreengrassBuildWithDockerDeploymentsIT.class);
@@ -96,25 +96,25 @@ public class GreengrassBuildWithDockerDeploymentsIT {
     }
 
     private GenericContainer startAndGetContainer(String arguments) {
-        String hostAwsCredentialsPath = String.join("/", getHome(), ".aws");
+        String hostAwsCredentialsPath = String.join("/", getHome(), DOT_AWS);
         MountableFile hostAwsCredentialsMountableFile = MountableFile.forHostPath(new File(hostAwsCredentialsPath).toPath());
-        String containerAwsCredentialsPath = "/root/.aws";
+        String containerAwsCredentialsPath = String.join("", "/root/", DOT_AWS);
 
-        String hostFoundationPath = getHostPath("foundation");
+        String hostFoundationPath = GreengrassITShared.FOUNDATION;
         MountableFile hostFoundationMountableFile = MountableFile.forHostPath(new File(hostFoundationPath).toPath());
-        String containerFoundationPath = "/foundation";
+        String containerFoundationPath = String.join("", "/", GreengrassITShared.FOUNDATION);
 
-        String hostDeploymentsPath = getHostPath("deployments");
+        String hostDeploymentsPath = GreengrassITShared.DEPLOYMENTS;
         MountableFile hostDeploymentsMountableFile = MountableFile.forHostPath(new File(hostDeploymentsPath).toPath());
-        String containerDeploymentsPath = "/deployments";
+        String containerDeploymentsPath = String.join("", "/", GreengrassITShared.DEPLOYMENTS);
 
-        String hostFunctionsPath = getHostPath("functions");
+        String hostFunctionsPath = GreengrassITShared.FUNCTIONS;
         MountableFile hostFunctionsMountableFile = MountableFile.forHostPath(new File(hostFunctionsPath).toPath());
-        String containerFunctionsPath = "/functions";
+        String containerFunctionsPath = String.join("", "/", GreengrassITShared.FUNCTIONS);
 
-        String hostGgdsPath = getHostPath("ggds");
+        String hostGgdsPath = GreengrassITShared.GGDS;
         MountableFile hostGgdsMountableFile = MountableFile.forHostPath(new File(hostGgdsPath).toPath());
-        String containerGgdsPath = "/ggds";
+        String containerGgdsPath = String.join("", "/", GreengrassITShared.GGDS);
 
         GenericContainer genericContainer = new GenericContainer<>(getContainerName())
                 .withCopyFileToContainer(hostAwsCredentialsMountableFile, containerAwsCredentialsPath)
@@ -127,11 +127,6 @@ public class GreengrassBuildWithDockerDeploymentsIT {
         genericContainer.start();
 
         return genericContainer;
-    }
-
-    @NotNull
-    private String getHostPath(String foundation) {
-        return String.join("/", "..", "aws-greengrass-lambda-functions", foundation);
     }
 
     private void waitForContainerToFinish(GenericContainer genericContainer) {

--- a/src/integration-test/java/GreengrassBuildWithDockerDeploymentsIT.java
+++ b/src/integration-test/java/GreengrassBuildWithDockerDeploymentsIT.java
@@ -24,7 +24,6 @@ import java.util.concurrent.TimeUnit;
 import static org.hamcrest.CoreMatchers.*;
 
 // NOTE: Ignoring these tests since currently testcontainers throws a java.lang.OutOfMemoryError on every test
-@Ignore
 public class GreengrassBuildWithDockerDeploymentsIT {
     private static final Matcher<Integer> EXIT_CODE_IS_ZERO = equalTo(0);
     private static final Matcher<Integer> EXIT_CODE_IS_NOT_ZERO = not(EXIT_CODE_IS_ZERO);

--- a/src/integration-test/java/GreengrassBuildWithDockerDeploymentsIT.java
+++ b/src/integration-test/java/GreengrassBuildWithDockerDeploymentsIT.java
@@ -26,7 +26,6 @@ import static org.hamcrest.CoreMatchers.*;
 // NOTE: Ignoring these tests since currently testcontainers throws a java.lang.OutOfMemoryError on every test
 @Ignore
 public class GreengrassBuildWithDockerDeploymentsIT {
-    public static final String AWS_GREENGRASS_LAMBDA_FUNCTIONS_VIA_PARENT_DIRECTORY = "../aws-greengrass-lambda-functions";
     private static final Matcher<Integer> EXIT_CODE_IS_ZERO = equalTo(0);
     private static final Matcher<Integer> EXIT_CODE_IS_NOT_ZERO = not(EXIT_CODE_IS_ZERO);
     private static Logger log = LoggerFactory.getLogger(GreengrassBuildWithDockerDeploymentsIT.class);
@@ -94,7 +93,7 @@ public class GreengrassBuildWithDockerDeploymentsIT {
     }
 
     private String getContainerName() {
-        return String.join(":", GreengrassITShared.TIMMATTISON_AWS_GREENGRASS_PROVISIONER, getBranch());
+        return String.join(":", GreengrassITShared.DOCKERHUB_TIMMATTISON_AWS_GREENGRASS_PROVISIONER, getBranch());
     }
 
     private GenericContainer startAndGetContainer(String arguments) {
@@ -228,7 +227,7 @@ public class GreengrassBuildWithDockerDeploymentsIT {
     // Test set 11: Reuse Python 3 Hello World in another group with Docker
     @Test
     public void shouldReusePython3FunctionWithDocker() throws IOException {
-        File tempDeploymentConfFile = greengrassITShared.setupReusedFunctionDeploymentConf(Optional.of(AWS_GREENGRASS_LAMBDA_FUNCTIONS_VIA_PARENT_DIRECTORY), GreengrassITShared.HELLO_WORLD_PYTHON_3_PROD_PARTIAL, greengrassITShared.getGroupName());
+        File tempDeploymentConfFile = greengrassITShared.setupReusedFunctionDeploymentConf(Optional.empty(), GreengrassITShared.HELLO_WORLD_PYTHON_3_PROD_PARTIAL, greengrassITShared.getGroupName());
 
         // Build it
         runContainer(greengrassITShared.getPython3HelloWorldDeploymentCommand(Optional.empty()), EXIT_CODE_IS_ZERO);
@@ -240,7 +239,7 @@ public class GreengrassBuildWithDockerDeploymentsIT {
     // Test set 12: Reuse Java benchmark in another group with Docker
     @Test
     public void shouldReuseJavaFunctionWithDocker() throws IOException {
-        File tempDeploymentConfFile = greengrassITShared.setupReusedFunctionDeploymentConf(Optional.of(AWS_GREENGRASS_LAMBDA_FUNCTIONS_VIA_PARENT_DIRECTORY), GreengrassITShared.BENCHMARK_JAVA_PROD_PARTIAL, greengrassITShared.getGroupName());
+        File tempDeploymentConfFile = greengrassITShared.setupReusedFunctionDeploymentConf(Optional.empty(), GreengrassITShared.BENCHMARK_JAVA_PROD_PARTIAL, greengrassITShared.getGroupName());
 
         // Build it
         runContainer(greengrassITShared.getBenchmarkDeploymentCommand(Optional.empty()), EXIT_CODE_IS_ZERO);
@@ -252,7 +251,7 @@ public class GreengrassBuildWithDockerDeploymentsIT {
     // Test set 13: Fail to reuse Java benchmark in another group with Docker
     @Test
     public void shouldFailToReuseBroadPatternFunctionWithDocker() throws IOException {
-        File tempDeploymentConfFile = greengrassITShared.setupReusedFunctionDeploymentConf(Optional.of(AWS_GREENGRASS_LAMBDA_FUNCTIONS_VIA_PARENT_DIRECTORY), GreengrassITShared.BENCHMARK_PROD_PARTIAL, greengrassITShared.getGroupName());
+        File tempDeploymentConfFile = greengrassITShared.setupReusedFunctionDeploymentConf(Optional.empty(), GreengrassITShared.BENCHMARK_PROD_PARTIAL, greengrassITShared.getGroupName());
 
         // Build it
         runContainer(greengrassITShared.getBenchmarkDeploymentCommand(Optional.empty()), EXIT_CODE_IS_ZERO);

--- a/src/integration-test/java/GreengrassITShared.java
+++ b/src/integration-test/java/GreengrassITShared.java
@@ -66,7 +66,7 @@ class GreengrassITShared {
 
         FileUtils.copyDirectory(GreengrassITShared.MASTER_DEPLOYMENTS, GreengrassITShared.TEMP_DEPLOYMENTS);
         FileUtils.copyDirectory(GreengrassITShared.MASTER_FOUNDATION, GreengrassITShared.TEMP_FOUNDATION);
-       
+
         IOFileFilter ignoreVenvDirectories = FileFilterUtils.notFileFilter(FileFilterUtils.nameFileFilter("venv"));
 
         FileUtils.copyDirectory(GreengrassITShared.MASTER_FUNCTIONS, GreengrassITShared.TEMP_FUNCTIONS, ignoreVenvDirectories);

--- a/src/integration-test/java/GreengrassITShared.java
+++ b/src/integration-test/java/GreengrassITShared.java
@@ -5,6 +5,8 @@ import com.awslabs.aws.greengrass.provisioner.data.arguments.UpdateArguments;
 import com.awslabs.aws.greengrass.provisioner.interfaces.helpers.IoHelper;
 import com.awslabs.aws.greengrass.provisioner.interfaces.helpers.ThreadHelper;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.filefilter.FileFilterUtils;
+import org.apache.commons.io.filefilter.IOFileFilter;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
@@ -15,13 +17,17 @@ class GreengrassITShared {
     static final String HELLO_WORLD_PYTHON_3_PROD_PARTIAL = "~HelloWorldPython3:PROD";
     static final String BENCHMARK_JAVA_PROD_PARTIAL = "~CDDBenchmarkJava:PROD";
     static final String BENCHMARK_PROD_PARTIAL = "~Benchmark~:PROD";
-    static final File MASTER_DEPLOYMENTS = new File("../aws-greengrass-lambda-functions/deployments");
-    static final File MASTER_FUNCTIONS = new File("../aws-greengrass-lambda-functions/functions");
-    static final File MASTER_FOUNDATION = new File("../aws-greengrass-lambda-functions/foundation");
-    static final String TIMMATTISON_AWS_GREENGRASS_PROVISIONER = "timmattison/aws-greengrass-provisioner";
-    static final File TEMP_DEPLOYMENTS = new File("deployments");
-    static final File TEMP_FUNCTIONS = new File("functions");
-    static final File TEMP_FOUNDATION = new File("foundation");
+    static final String LAMBDA_FUNCTIONS_DIRECTORY_VIA_PARENT = String.join("/", "..", "aws-greengrass-lambda-functions");
+    static final String DEPLOYMENTS = "deployments";
+    static final String FUNCTIONS = "functions";
+    static final String FOUNDATION = "foundation";
+    static final File MASTER_DEPLOYMENTS = new File(String.join("/", LAMBDA_FUNCTIONS_DIRECTORY_VIA_PARENT, DEPLOYMENTS));
+    static final File MASTER_FUNCTIONS = new File(String.join("/", LAMBDA_FUNCTIONS_DIRECTORY_VIA_PARENT, FUNCTIONS));
+    static final File MASTER_FOUNDATION = new File(String.join("/", LAMBDA_FUNCTIONS_DIRECTORY_VIA_PARENT, FOUNDATION));
+    static final String DOCKERHUB_TIMMATTISON_AWS_GREENGRASS_PROVISIONER = "timmattison/aws-greengrass-provisioner";
+    static final File TEMP_DEPLOYMENTS = new File(DEPLOYMENTS);
+    static final File TEMP_FUNCTIONS = new File(FUNCTIONS);
+    static final File TEMP_FOUNDATION = new File(FOUNDATION);
     static final File TEMP_CREDENTIALS = new File("credentials");
     /**
      * This is used to generate files that can be used in end-to-end tests
@@ -59,8 +65,11 @@ class GreengrassITShared {
         cleanDirectories();
 
         FileUtils.copyDirectory(GreengrassITShared.MASTER_DEPLOYMENTS, GreengrassITShared.TEMP_DEPLOYMENTS);
-        FileUtils.copyDirectory(GreengrassITShared.MASTER_FUNCTIONS, GreengrassITShared.TEMP_FUNCTIONS);
         FileUtils.copyDirectory(GreengrassITShared.MASTER_FOUNDATION, GreengrassITShared.TEMP_FOUNDATION);
+       
+        IOFileFilter ignoreVenvDirectories = FileFilterUtils.notFileFilter(FileFilterUtils.nameFileFilter("venv"));
+
+        FileUtils.copyDirectory(GreengrassITShared.MASTER_FUNCTIONS, GreengrassITShared.TEMP_FUNCTIONS, ignoreVenvDirectories);
     }
 
     String getGroupName() {
@@ -153,10 +162,10 @@ class GreengrassITShared {
 
     @NotNull
     private File writeTempDeploymentConfFile(Optional<String> optionalDirectoryPrefix, String tempDeploymentConfContents) throws IOException {
-        String directory = "deployments";
+        String directory = DEPLOYMENTS;
 
         if (optionalDirectoryPrefix.isPresent()) {
-            directory = optionalDirectoryPrefix.get() + "/" + directory;
+            directory = String.join("/", optionalDirectoryPrefix.get(), directory);
         }
 
         File tempDeploymentConfFile = File.createTempFile("temp-deployment-", ".conf", new File(directory));

--- a/src/integration-test/java/GreengrassITShared.java
+++ b/src/integration-test/java/GreengrassITShared.java
@@ -21,14 +21,17 @@ class GreengrassITShared {
     static final String DEPLOYMENTS = "deployments";
     static final String FUNCTIONS = "functions";
     static final String FOUNDATION = "foundation";
+    static final String GGDS = "ggds";
     static final File MASTER_DEPLOYMENTS = new File(String.join("/", LAMBDA_FUNCTIONS_DIRECTORY_VIA_PARENT, DEPLOYMENTS));
     static final File MASTER_FUNCTIONS = new File(String.join("/", LAMBDA_FUNCTIONS_DIRECTORY_VIA_PARENT, FUNCTIONS));
     static final File MASTER_FOUNDATION = new File(String.join("/", LAMBDA_FUNCTIONS_DIRECTORY_VIA_PARENT, FOUNDATION));
+    static final File MASTER_GGDS = new File(String.join("/", LAMBDA_FUNCTIONS_DIRECTORY_VIA_PARENT, GGDS));
     static final String DOCKERHUB_TIMMATTISON_AWS_GREENGRASS_PROVISIONER = "timmattison/aws-greengrass-provisioner";
     static final File TEMP_DEPLOYMENTS = new File(DEPLOYMENTS);
     static final File TEMP_FUNCTIONS = new File(FUNCTIONS);
     static final File TEMP_FOUNDATION = new File(FOUNDATION);
     static final File TEMP_CREDENTIALS = new File("credentials");
+    static final File TEMP_GGDS = new File(GGDS);
     /**
      * This is used to generate files that can be used in end-to-end tests
      */
@@ -55,6 +58,7 @@ class GreengrassITShared {
         FileUtils.deleteDirectory(TEMP_FUNCTIONS);
         FileUtils.deleteDirectory(TEMP_FOUNDATION);
         FileUtils.deleteDirectory(TEMP_CREDENTIALS);
+        FileUtils.deleteDirectory(TEMP_GGDS);
     }
 
     static ThreadHelper getThreadHelper() {
@@ -70,6 +74,7 @@ class GreengrassITShared {
         IOFileFilter ignoreVenvDirectories = FileFilterUtils.notFileFilter(FileFilterUtils.nameFileFilter("venv"));
 
         FileUtils.copyDirectory(GreengrassITShared.MASTER_FUNCTIONS, GreengrassITShared.TEMP_FUNCTIONS, ignoreVenvDirectories);
+        FileUtils.copyDirectory(GreengrassITShared.MASTER_GGDS, GreengrassITShared.TEMP_GGDS, ignoreVenvDirectories);
     }
 
     String getGroupName() {

--- a/src/integration-test/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/DuplicateLocalResourceIT.java
+++ b/src/integration-test/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/DuplicateLocalResourceIT.java
@@ -1,0 +1,89 @@
+package com.awslabs.aws.greengrass.provisioner.implementations.helpers;
+
+import com.awslabs.aws.greengrass.provisioner.AwsGreengrassProvisioner;
+import com.awslabs.aws.greengrass.provisioner.data.resources.*;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DuplicateLocalResourceIT {
+    public static final String TEMPDIR_1 = "/tempdir1";
+    public static final String TMP_1 = "/tmp1";
+    public static final String TMP_2 = "/tmp2";
+    public static final String TMP = "/tmp";
+    public static final String TEMPDIR_2 = "/tempdir2";
+    private BasicGreengrassHelper basicGreengrassHelper;
+    private List<LocalDeviceResource> localDeviceResources = new ArrayList<>();
+    private List<LocalVolumeResource> localVolumeResources = new ArrayList<>();
+    private List<LocalS3Resource> localS3Resources = new ArrayList<>();
+    private List<LocalSageMakerResource> localSageMakerResources = new ArrayList<>();
+    private List<LocalSecretsManagerResource> localSecretsManagerResources = new ArrayList<>();
+
+    @Before
+    public void setup() {
+        basicGreengrassHelper = AwsGreengrassProvisioner.getInjector().getInstance(BasicGreengrassHelper.class);
+    }
+
+    @Test
+    public void shouldFilterOutDuplicateLocalVolumeResources() {
+        LocalVolumeResource localVolumeResource1 = ImmutableLocalVolumeResource.builder()
+                .sourcePath(TMP)
+                .destinationPath(TMP)
+                .isReadWrite(true)
+                .build();
+
+        LocalVolumeResource localVolumeResource2 = ImmutableLocalVolumeResource.copyOf(localVolumeResource1);
+
+        localVolumeResources.clear();
+        localVolumeResources.add(localVolumeResource1);
+        localVolumeResources.add(localVolumeResource2);
+
+        basicGreengrassHelper.createResourceDefinition(localDeviceResources, localVolumeResources, localS3Resources, localSageMakerResources, localSecretsManagerResources);
+    }
+
+    @Test
+    public void shouldFailWhenSourcePathsAreTheSameAndDestinationPathsAreDifferent() {
+        LocalVolumeResource localVolumeResource1 = ImmutableLocalVolumeResource.builder()
+                .sourcePath(TMP)
+                .destinationPath(TEMPDIR_1)
+                .isReadWrite(true)
+                .build();
+
+        LocalVolumeResource localVolumeResource2 = ImmutableLocalVolumeResource.builder()
+                .sourcePath(TMP)
+                .destinationPath(TEMPDIR_2)
+                .isReadWrite(true)
+                .build();
+
+        localVolumeResources.clear();
+        localVolumeResources.add(localVolumeResource1);
+        localVolumeResources.add(localVolumeResource2);
+
+        RuntimeException runtimeException = Assert.assertThrows(RuntimeException.class, () -> basicGreengrassHelper.createResourceDefinition(localDeviceResources, localVolumeResources, localS3Resources, localSageMakerResources, localSecretsManagerResources));
+        Assert.assertTrue(runtimeException.getMessage().contains("Invalid resource configuration"));
+    }
+
+    @Test
+    public void shouldNotFailWhenSourcePathsAreDifferentAndDestinationPathsAreTheSame() {
+        LocalVolumeResource localVolumeResource1 = ImmutableLocalVolumeResource.builder()
+                .sourcePath(TMP_1)
+                .destinationPath(TEMPDIR_1)
+                .isReadWrite(true)
+                .build();
+
+        LocalVolumeResource localVolumeResource2 = ImmutableLocalVolumeResource.builder()
+                .sourcePath(TMP_2)
+                .destinationPath(TEMPDIR_1)
+                .isReadWrite(true)
+                .build();
+
+        localVolumeResources.clear();
+        localVolumeResources.add(localVolumeResource1);
+        localVolumeResources.add(localVolumeResource2);
+
+        basicGreengrassHelper.createResourceDefinition(localDeviceResources, localVolumeResources, localS3Resources, localSageMakerResources, localSecretsManagerResources);
+    }
+}

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/data/resources/LocalDeviceResource.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/data/resources/LocalDeviceResource.java
@@ -3,10 +3,6 @@ package com.awslabs.aws.greengrass.provisioner.data.resources;
 import org.immutables.value.Value;
 
 @Value.Immutable
-public abstract class LocalDeviceResource {
-    public abstract String getName();
-
-    public abstract String getPath();
-
+public abstract class LocalDeviceResource implements LocalResource {
     public abstract boolean isReadWrite();
 }

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/data/resources/LocalResource.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/data/resources/LocalResource.java
@@ -1,0 +1,22 @@
+package com.awslabs.aws.greengrass.provisioner.data.resources;
+
+import java.util.Optional;
+
+public interface LocalResource {
+    default String getName() {
+        return getSafeName();
+    }
+
+    String getPath();
+
+    default String getSafeName() {
+        // Device names can't have special characters in them - https://docs.aws.amazon.com/greengrass/latest/apireference/createresourcedefinition-post.html
+        return Optional.of(getPath()
+                .replaceAll("[^a-zA-Z0-9:_-]", "-")
+                .replaceFirst("^-", "")
+                .replaceFirst("-$", "")
+                .trim())
+                .orElseThrow(() -> new RuntimeException("Path cannot be empty"));
+    }
+
+}

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/data/resources/LocalS3Resource.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/data/resources/LocalS3Resource.java
@@ -3,10 +3,6 @@ package com.awslabs.aws.greengrass.provisioner.data.resources;
 import org.immutables.value.Value;
 
 @Value.Immutable
-public abstract class LocalS3Resource {
-    public abstract String getName();
-
+public abstract class LocalS3Resource implements LocalResource {
     public abstract String getUri();
-
-    public abstract String getPath();
 }

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/data/resources/LocalSageMakerResource.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/data/resources/LocalSageMakerResource.java
@@ -3,10 +3,6 @@ package com.awslabs.aws.greengrass.provisioner.data.resources;
 import org.immutables.value.Value;
 
 @Value.Immutable
-public abstract class LocalSageMakerResource {
-    public abstract String getName();
-
+public abstract class LocalSageMakerResource implements LocalResource {
     public abstract String getArn();
-
-    public abstract String getPath();
 }

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/data/resources/LocalVolumeResource.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/data/resources/LocalVolumeResource.java
@@ -3,10 +3,12 @@ package com.awslabs.aws.greengrass.provisioner.data.resources;
 import org.immutables.value.Value;
 
 @Value.Immutable
-public abstract class LocalVolumeResource {
-    public abstract String getName();
-
+public abstract class LocalVolumeResource implements LocalResource {
     public abstract String getSourcePath();
+
+    public String getPath() {
+        return String.join("-", getSourcePath(), getDestinationPath());
+    }
 
     public abstract String getDestinationPath();
 

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicDeploymentHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicDeploymentHelper.java
@@ -698,7 +698,7 @@ public class BasicDeploymentHelper implements DeploymentHelper {
         ////////////////////////////
 
         log.info("Creating resource definition");
-        String resourceDefinitionVersionArn = greengrassHelper.createResourceDefinitionVersion(functionConfs);
+        String resourceDefinitionVersionArn = greengrassHelper.createResourceDefinitionFromFunctionConfs(functionConfs);
 
         /////////////////////////////////////////////////////////////////////////
         // Build the function definition for the Lambda function and a version //

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicFunctionHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicFunctionHelper.java
@@ -424,11 +424,7 @@ public class BasicFunctionHelper implements FunctionHelper {
 
             String path = temp.getString(PATH);
 
-            Optional<String> optionalName = getName(temp);
-            String name = makeNameSafe(path, optionalName);
-
             LocalDeviceResource localDeviceResource = ImmutableLocalDeviceResource.builder()
-                    .name(name)
                     .path(path)
                     .isReadWrite(temp.getBoolean(READ_WRITE))
                     .build();
@@ -453,11 +449,7 @@ public class BasicFunctionHelper implements FunctionHelper {
                     .recover(ConfigException.Missing.class, throwable -> sourcePath)
                     .get();
 
-            Optional<String> optionalName = getName(temp);
-            String name = makeNameSafe(sourcePath, optionalName);
-
             LocalVolumeResource localVolumeResource = ImmutableLocalVolumeResource.builder()
-                    .name(name)
                     .sourcePath(sourcePath)
                     .destinationPath(destinationPath)
                     .isReadWrite(temp.getBoolean(READ_WRITE))
@@ -479,11 +471,7 @@ public class BasicFunctionHelper implements FunctionHelper {
             String uri = temp.getString(URI);
             String path = temp.getString(PATH);
 
-            Optional<String> optionalName = getName(temp);
-            String name = makeNameSafe(path, optionalName);
-
             LocalS3Resource localS3Resource = ImmutableLocalS3Resource.builder()
-                    .name(name)
                     .uri(uri)
                     .path(path)
                     .build();
@@ -528,11 +516,7 @@ public class BasicFunctionHelper implements FunctionHelper {
                 throw new RuntimeException("SageMaker ARNs must be training job ARNs, not model ARNs or other types of ARNs [" + arn + "]");
             }
 
-            Optional<String> optionalName = getName(temp);
-            String name = makeNameSafe(path, optionalName);
-
             LocalSageMakerResource localSageMakerResource = ImmutableLocalSageMakerResource.builder()
-                    .name(name)
                     .arn(arn)
                     .path(path)
                     .build();
@@ -604,16 +588,6 @@ public class BasicFunctionHelper implements FunctionHelper {
         return Try.of(() -> Optional.of(config.getString("name")))
                 .recover(ConfigException.Missing.class, throwable -> Optional.empty())
                 .get();
-    }
-
-    private String makeNameSafe(String path, Optional<String> name) {
-        // Device names can't have special characters in them - https://docs.aws.amazon.com/greengrass/latest/apireference/createresourcedefinition-post.html
-        return Optional.of(name.orElse(path)
-                .replaceAll("[^a-zA-Z0-9:_-]", "-")
-                .replaceFirst("^-", "")
-                .replaceFirst("-$", "")
-                .trim())
-                .orElseThrow(() -> new RuntimeException("Name cannot be empty"));
     }
 
     private void setEnvironmentVariablesFromConf(ImmutableFunctionConf.Builder functionConfBuilder, Config config) {

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGreengrassHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGreengrassHelper.java
@@ -697,7 +697,7 @@ public class BasicGreengrassHelper implements GreengrassHelper {
     }
 
     @Override
-    public String createResourceDefinitionVersion(List<FunctionConf> functionConfs) {
+    public String createResourceDefinitionFromFunctionConfs(List<FunctionConf> functionConfs) {
         // Log that the local resources from functions outside of the Greengrass container will be scrubbed
         functionConfs.stream()
                 .filter(functionConf -> !functionConf.isGreengrassContainer())

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGreengrassResourceHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGreengrassResourceHelper.java
@@ -1,5 +1,6 @@
 package com.awslabs.aws.greengrass.provisioner.implementations.helpers;
 
+import com.awslabs.aws.greengrass.provisioner.data.conf.FunctionConf;
 import com.awslabs.aws.greengrass.provisioner.interfaces.helpers.GreengrassResourceHelper;
 import io.vavr.control.Try;
 import org.slf4j.Logger;
@@ -58,6 +59,14 @@ public class BasicGreengrassResourceHelper implements GreengrassResourceHelper {
                 .collect(Collectors.toList());
 
         disallowDuplicateSecretsManagerSecrets(localSecretsManagerResources);
+    }
+
+    @Override
+    public <R> List<R> flatMapResources(List<FunctionConf> functionConfs, java.util.function.Function<FunctionConf, List<R>> method) {
+        return functionConfs.stream()
+                .map(method)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
     }
 
     private void disallowDuplicateSecretsManagerSecrets(List<SecretsManagerSecretResourceData> resources) {
@@ -157,5 +166,17 @@ public class BasicGreengrassResourceHelper implements GreengrassResourceHelper {
         }
 
         return Optional.empty();
+    }
+
+    private Optional<List<Map.Entry<String, Set<String>>>> findMultipleDestinations(Map<String, Set<String>> inputMap) {
+        List<Map.Entry<String, Set<String>>> duplicates = inputMap.entrySet().stream()
+                .filter(entry -> entry.getValue().size() > 1)
+                .collect(Collectors.toList());
+
+        if (duplicates.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(duplicates);
     }
 }

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/interfaces/helpers/GreengrassHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/interfaces/helpers/GreengrassHelper.java
@@ -60,7 +60,7 @@ public interface GreengrassHelper {
 
     DeploymentStatus waitForDeploymentStatusToChange(String groupId, String deploymentId);
 
-    String createResourceDefinitionVersion(List<FunctionConf> functionConfs);
+    String createResourceDefinitionFromFunctionConfs(List<FunctionConf> functionConfs);
 
     Device getDevice(String thingName);
 

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/interfaces/helpers/GreengrassResourceHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/interfaces/helpers/GreengrassResourceHelper.java
@@ -1,7 +1,12 @@
 package com.awslabs.aws.greengrass.provisioner.interfaces.helpers;
 
+import com.awslabs.aws.greengrass.provisioner.data.conf.FunctionConf;
 import software.amazon.awssdk.services.greengrass.model.ResourceDefinitionVersion;
+
+import java.util.List;
 
 public interface GreengrassResourceHelper {
     void validateResourceDefinitionVersion(ResourceDefinitionVersion resourceDefinitionVersion);
+
+    <R> List<R> flatMapResources(List<FunctionConf> functionConfs, java.util.function.Function<FunctionConf, List<R>> method);
 }


### PR DESCRIPTION
Fixes #448 

Performs some validation and gives informative error messages if a user tries to do something that will be rejected by the cloud (e.g. a source path that has two different destination paths).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
