### PR TITLE
Functions inside the Greengrass container can now run as any uid/gid

### DIFF
--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicDeploymentHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicDeploymentHelper.java
@@ -754,23 +754,10 @@ public class BasicDeploymentHelper implements DeploymentHelper {
         ////////////////////////////////////////////////////
 
         boolean functionsRunningAsRoot = functionConfs.stream()
-                .filter(functionConf -> (functionConf.getUid() == 0) || (functionConf.getGid() == 0))
-                .anyMatch(functionConf -> !functionConf.isGreengrassContainer());
+                .anyMatch(functionConf -> (functionConf.getUid() == 0) || (functionConf.getGid() == 0));
 
         if (functionsRunningAsRoot) {
-            log.warn("At least one function was detected that is configured to run outside of the Greengrass container as root");
-        }
-
-        ///////////////////////////////////////////////////////////////////////////////////////////////////////
-        // Determine if any functions are specified to run as root but are still set to run in the container //
-        ///////////////////////////////////////////////////////////////////////////////////////////////////////
-
-        boolean functionsWithRootUidOrGidInGreengrassContainer = functionConfs.stream()
-                .filter(functionConf -> (functionConf.getUid() == 0) || (functionConf.getGid() == 0))
-                .anyMatch(FunctionConf::isGreengrassContainer);
-
-        if (functionsWithRootUidOrGidInGreengrassContainer) {
-            log.warn("At least one function was detected that is configured to run as root but will run as the Greengrass user because it is set to run inside of the Greengrass container. If you need a function to run as root it must run outside of the Greengrass container.");
+            log.warn("At least one function was detected that is configured to run as root");
         }
 
         ////////////////////////////////////////////////////////////////////////////

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGreengrassHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGreengrassHelper.java
@@ -260,9 +260,10 @@ public class BasicGreengrassHelper implements GreengrassHelper {
 
             functionConfigurationBuilder = functionConfigurationBuilder.memorySize(functionConf.getMemorySizeInKb());
         } else {
-            functionExecutionConfigBuilder = functionExecutionConfigBuilder.isolationMode(FunctionIsolationMode.NO_CONTAINER)
-                    .runAs(FunctionRunAsConfig.builder().uid(functionConf.getUid()).gid(functionConf.getGid()).build());
+            functionExecutionConfigBuilder = functionExecutionConfigBuilder.isolationMode(FunctionIsolationMode.NO_CONTAINER);
         }
+
+        functionExecutionConfigBuilder.runAs(FunctionRunAsConfig.builder().uid(functionConf.getUid()).gid(functionConf.getGid()).build());
 
         functionConfigurationEnvironmentBuilder.resourceAccessPolicies(resourceAccessPolicies);
 

--- a/testing/integration-test.sh
+++ b/testing/integration-test.sh
@@ -11,6 +11,8 @@ set -e
 find ../aws-greengrass-lambda-functions -name "build.gradle" -exec sh -c 'cd $(dirname {}); ./gradlew clean' \;
 find ../aws-greengrass-lambda-functions/functions -name "venv" -exec rm -rf {} \;
 
+./testing/push-to-dockerhub.sh
+
 rm -rf build out credentials
 ./gradlew clean build integrationTest $@
 rm -rf out credentials


### PR DESCRIPTION
Fixes #527 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
