### PR TITLE
Migrate functions to library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ def awsIotCoreWebsocketsVersion = '0.6.3'
 def awaitilityVersion = '4.0.2'
 def immutablesValueVersion = '2.8.3'
 def awsLambdaJavaCoreVersion = '1.2.0'
-def resultsIteratorForAwsJavaSdkVersion = '0.7.2'
+def resultsIteratorForAwsJavaSdkVersion = '0.7.9'
 
 def buildDirDist = "$buildDir/dist"
 def buildDirFoundation = "$buildDir/foundation"

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/AwsGreengrassProvisionerModule.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/AwsGreengrassProvisionerModule.java
@@ -18,7 +18,6 @@ import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ecr.EcrClient;
-import software.amazon.awssdk.services.greengrass.GreengrassClient;
 import software.amazon.awssdk.services.iot.IotClient;
 import software.amazon.awssdk.services.lambda.LambdaClient;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
@@ -40,11 +39,6 @@ public class AwsGreengrassProvisionerModule {
     @Provides
     public CloudWatchLogsClient provideCloudWatchLogsClient() {
         return new V2SafeProvider<>(CloudWatchLogsClient::create).get();
-    }
-
-    @Provides
-    public GreengrassClient provideGreengrassClient() {
-        return new V2SafeProvider<>(GreengrassClient::create).get();
     }
 
     @Provides

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/Injector.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/Injector.java
@@ -3,6 +3,7 @@ package com.awslabs.aws.greengrass.provisioner;
 import com.awslabs.aws.greengrass.provisioner.interfaces.helpers.*;
 import com.awslabs.aws.greengrass.provisioner.lambda.AwsGreengrassProvisionerLambda;
 import com.awslabs.general.helpers.interfaces.JsonHelper;
+import com.awslabs.iot.helpers.interfaces.V2GreengrassHelper;
 import com.awslabs.resultsiterator.v2.interfaces.V2SdkErrorHandler;
 import dagger.Component;
 
@@ -16,6 +17,7 @@ public interface Injector {
     GlobalDefaultHelper globalDefaultHelper();
     ProcessHelper processHelper();
     GreengrassHelper greengrassHelper();
+    V2GreengrassHelper v2GreengrassHelper();
     DeploymentHelper deploymentHelper();
     GGVariables ggVariables();
     JsonHelper jsonHelper();

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicDeploymentHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicDeploymentHelper.java
@@ -14,6 +14,7 @@ import com.awslabs.aws.greengrass.provisioner.interfaces.ExceptionHelper;
 import com.awslabs.aws.greengrass.provisioner.interfaces.helpers.*;
 import com.awslabs.general.helpers.interfaces.JsonHelper;
 import com.awslabs.iam.helpers.interfaces.V2IamHelper;
+import com.awslabs.iot.helpers.interfaces.V2GreengrassHelper;
 import com.google.common.collect.ImmutableSet;
 import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
@@ -89,6 +90,8 @@ public class BasicDeploymentHelper implements DeploymentHelper {
     V2IamHelper iamHelper;
     @Inject
     GreengrassHelper greengrassHelper;
+    @Inject
+    V2GreengrassHelper v2GreengrassHelper;
     @Inject
     IoHelper ioHelper;
     @Inject
@@ -456,7 +459,7 @@ public class BasicDeploymentHelper implements DeploymentHelper {
         // Create an AWS Greengrass Group and get its ID //
         ///////////////////////////////////////////////////
 
-        if (greengrassHelper.groupExists(deploymentArguments.groupName) && (deploymentArguments.ec2LinuxVersion != null)) {
+        if (v2GreengrassHelper.groupExistsByName(deploymentArguments.groupName) && (deploymentArguments.ec2LinuxVersion != null)) {
             throw new RuntimeException("Group [" + deploymentArguments.groupName + "] already exists, cannot launch another EC2 instance for this group.  You can update the group configuration by not specifying the EC2 launch option.");
         }
 
@@ -618,7 +621,7 @@ public class BasicDeploymentHelper implements DeploymentHelper {
         // Create or reuse certificates //
         //////////////////////////////////
 
-        Optional<GroupVersion> optionalGroupVersion = greengrassHelper.getLatestGroupVersion(groupId);
+        Optional<GroupVersion> optionalGroupVersion = v2GreengrassHelper.getLatestGroupVersionByNameOrId(groupId);
         Optional<KeysAndCertificate> optionalCoreKeysAndCertificate = Optional.empty();
 
         Optional<String> optionalCoreCertificateArn = Optional.empty();

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGreengrassHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGreengrassHelper.java
@@ -7,6 +7,7 @@ import com.awslabs.aws.greengrass.provisioner.data.exceptions.IamReassociationNe
 import com.awslabs.aws.greengrass.provisioner.data.resources.*;
 import com.awslabs.aws.greengrass.provisioner.interfaces.helpers.*;
 import com.awslabs.iot.helpers.interfaces.GreengrassIdExtractor;
+import com.awslabs.iot.helpers.interfaces.V2GreengrassHelper;
 import com.google.common.collect.ImmutableSet;
 import io.vavr.control.Try;
 import net.jodah.failsafe.Failsafe;
@@ -49,6 +50,8 @@ public class BasicGreengrassHelper implements GreengrassHelper {
     GreengrassResourceHelper greengrassResourceHelper;
     @Inject
     ConnectorHelper connectorHelper;
+    @Inject
+    V2GreengrassHelper v2GreengrassHelper;
 
     @Inject
     public BasicGreengrassHelper() {
@@ -64,92 +67,13 @@ public class BasicGreengrassHelper implements GreengrassHelper {
     }
 
     @Override
-    public Optional<GroupInformation> getGroupInformation(String groupNameOrGroupId) {
-        ListGroupsRequest listGroupsRequest = ListGroupsRequest.builder().build();
-
-        ListGroupsResponse listGroupsResponse;
-
-        do {
-            listGroupsResponse = greengrassClient.listGroups(listGroupsRequest);
-
-            for (GroupInformation groupInformation : listGroupsResponse.groups()) {
-                if (groupInformation.name().equals(groupNameOrGroupId)) {
-                    return Optional.ofNullable(groupInformation);
-                }
-
-                if (groupInformation.id().equals(groupNameOrGroupId)) {
-                    return Optional.ofNullable(groupInformation);
-                }
-            }
-
-            listGroupsRequest = ListGroupsRequest.builder().nextToken(listGroupsResponse.nextToken()).build();
-        } while (listGroupsResponse.nextToken() != null);
-
-        log.warn("No group was found with name or ID [" + groupNameOrGroupId + "]");
-        return Optional.empty();
-    }
-
-    private Optional<String> getGroupId(String groupName) {
-        Optional<GroupInformation> optionalGroupInformation = getGroupInformation(groupName);
-
-        return optionalGroupInformation.map(GroupInformation::id);
-    }
-
-    private String getCoreDefinitionId(String coreDefinitionName) {
-        ListCoreDefinitionsRequest listCoreDefinitionsRequest = ListCoreDefinitionsRequest.builder().build();
-
-        ListCoreDefinitionsResponse listCoreDefinitionsResponse;
-
-        do {
-            listCoreDefinitionsResponse = greengrassClient.listCoreDefinitions(listCoreDefinitionsRequest);
-
-            for (DefinitionInformation definitionInformation : listCoreDefinitionsResponse.definitions()) {
-                if (definitionInformation.name() == null) {
-                    continue;
-                }
-
-                if (definitionInformation.name().equals(coreDefinitionName)) {
-                    return definitionInformation.id();
-                }
-            }
-
-            listCoreDefinitionsRequest = ListCoreDefinitionsRequest.builder().nextToken(listCoreDefinitionsResponse.nextToken()).build();
-        } while (listCoreDefinitionsResponse.nextToken() != null);
-
-        return null;
-    }
-
-    private String getDeviceDefinitionId(String deviceDefinitionName) {
-        ListDeviceDefinitionsRequest listDeviceDefinitionsRequest = ListDeviceDefinitionsRequest.builder().build();
-
-        ListDeviceDefinitionsResponse listDeviceDefinitionsResponse;
-
-        do {
-            listDeviceDefinitionsResponse = greengrassClient.listDeviceDefinitions(listDeviceDefinitionsRequest);
-
-            for (DefinitionInformation definitionInformation : listDeviceDefinitionsResponse.definitions()) {
-                if (definitionInformation.name() == null) {
-                    continue;
-                }
-
-                if (definitionInformation.name().equals(deviceDefinitionName)) {
-                    return definitionInformation.id();
-                }
-            }
-
-            listDeviceDefinitionsRequest = ListDeviceDefinitionsRequest.builder().nextToken(listDeviceDefinitionsResponse.nextToken()).build();
-        } while (listDeviceDefinitionsResponse.nextToken() != null);
-
-        return null;
-    }
-
-    @Override
     public String createGroupIfNecessary(String groupName) {
-        Optional<String> optionalGroupId = getGroupId(groupName);
+        Optional<GroupInformation> optionalGroupInformation = v2GreengrassHelper.getGroupInformationByName(groupName)
+                .findFirst();
 
-        if (optionalGroupId.isPresent()) {
+        if (optionalGroupInformation.isPresent()) {
             log.info("Group already exists, not creating a new one");
-            return optionalGroupId.get();
+            return optionalGroupInformation.get().id();
         }
 
         log.info("Group does not exist, creating a new one");
@@ -160,13 +84,6 @@ public class BasicGreengrassHelper implements GreengrassHelper {
         CreateGroupResponse createGroupResponse = greengrassClient.createGroup(createGroupRequest);
 
         return createGroupResponse.id();
-    }
-
-    @Override
-    public boolean groupExists(String groupName) {
-        Optional<String> optionalGroupId = getGroupId(groupName);
-
-        return optionalGroupId.isPresent();
     }
 
     @Override
@@ -183,15 +100,18 @@ public class BasicGreengrassHelper implements GreengrassHelper {
     public String createCoreDefinitionAndVersion(String coreDefinitionName, String coreCertificateArn, String coreThingArn, boolean syncShadow) {
         String uuid = ioHelper.getUuid();
 
-        String coreDefinitionId = getCoreDefinitionId(coreDefinitionName);
+        Optional<String> optionalCoreDefinitionId = v2GreengrassHelper.getCoreDefinitionIdByName(coreDefinitionName);
+        String coreDefinitionId = null;
 
-        if (coreDefinitionId == null) {
+        if (!optionalCoreDefinitionId.isPresent()) {
             CreateCoreDefinitionRequest createCoreDefinitionRequest = CreateCoreDefinitionRequest.builder()
                     .name(coreDefinitionName)
                     .build();
 
             CreateCoreDefinitionResponse createCoreDefinitionResponse = greengrassClient.createCoreDefinition(createCoreDefinitionRequest);
             coreDefinitionId = createCoreDefinitionResponse.id();
+        } else {
+            coreDefinitionId = optionalCoreDefinitionId.get();
         }
 
         Core core = Core.builder()
@@ -443,15 +363,18 @@ public class BasicGreengrassHelper implements GreengrassHelper {
 
     @Override
     public String createDeviceDefinitionAndVersion(String deviceDefinitionName, List<Device> devices) {
-        String deviceDefinitionId = getDeviceDefinitionId(deviceDefinitionName);
+        Optional<String> optionalDeviceDefinitionId = v2GreengrassHelper.getDeviceDefinitionIdByName(deviceDefinitionName);
+        String deviceDefinitionId = null;
 
-        if (deviceDefinitionId == null) {
+        if (!optionalDeviceDefinitionId.isPresent()) {
             CreateDeviceDefinitionRequest createDeviceDefinitionRequest = CreateDeviceDefinitionRequest.builder()
                     .name(deviceDefinitionName)
                     .build();
 
             CreateDeviceDefinitionResponse createDeviceDefinitionResponse = greengrassClient.createDeviceDefinition(createDeviceDefinitionRequest);
             deviceDefinitionId = createDeviceDefinitionResponse.id();
+        } else {
+            deviceDefinitionId = optionalDeviceDefinitionId.get();
         }
 
         CreateDeviceDefinitionVersionRequest createDeviceDefinitionVersionRequest = CreateDeviceDefinitionVersionRequest.builder()
@@ -533,7 +456,8 @@ public class BasicGreengrassHelper implements GreengrassHelper {
 
     @Override
     public String createGroupVersion(String groupId, GroupVersion newGroupVersion) {
-        Optional<GroupInformation> optionalGroupInformation = getGroupInformation(groupId);
+        Optional<GroupInformation> optionalGroupInformation = v2GreengrassHelper.getGroupInformationById(groupId).findFirst();
+
         GroupVersion currentGroupVersion = null;
         GroupInformation groupInformation = null;
 
@@ -556,7 +480,8 @@ public class BasicGreengrassHelper implements GreengrassHelper {
             // There is no current version so just use the new version as our reference
             currentGroupVersion = newGroupVersion;
         } else {
-            currentGroupVersion = getLatestGroupVersion(groupInformation);
+            currentGroupVersion = v2GreengrassHelper.getLatestGroupVersionByGroupInformation(groupInformation)
+                    .orElseThrow(() -> new RuntimeException("Group not found, can not continue"));
         }
 
         // When an ARN in the new version is NULL we take it from the current version.  This allows us to do updates more easily.
@@ -986,182 +911,6 @@ public class BasicGreengrassHelper implements GreengrassHelper {
     }
 
     @Override
-    public Optional<GroupVersion> getLatestGroupVersion(String groupId) {
-        Optional<GroupInformation> optionalGroupInformation = getGroupInformation(groupId);
-
-        if (!optionalGroupInformation.isPresent()) {
-            return Optional.empty();
-        }
-
-        GroupInformation groupInformation = optionalGroupInformation.get();
-
-        if (groupInformation.latestVersion() == null) {
-            // Can not get the latest version if the latest version field is NULL
-            return Optional.empty();
-        }
-
-        return Optional.of(getLatestGroupVersion(groupInformation));
-    }
-
-    @Override
-    public Optional<String> getCoreCertificateArn(String groupId) {
-        Optional<GroupVersion> optionalGroupVersion = getLatestGroupVersion(groupId);
-
-        if (!optionalGroupVersion.isPresent()) {
-            return Optional.empty();
-        }
-
-        GroupVersion groupVersion = optionalGroupVersion.get();
-
-        String coreDefinitionVersionArn = groupVersion.coreDefinitionVersionArn();
-        String coreDefinitionVersionId = idExtractor.extractVersionId(coreDefinitionVersionArn);
-        String coreDefinitionId = idExtractor.extractId(coreDefinitionVersionArn);
-
-        GetCoreDefinitionVersionRequest getCoreDefinitionVersionRequest = GetCoreDefinitionVersionRequest.builder()
-                .coreDefinitionVersionId(coreDefinitionVersionId)
-                .coreDefinitionId(coreDefinitionId)
-                .build();
-
-        GetCoreDefinitionVersionResponse coreDefinitionVersionResponse = greengrassClient.getCoreDefinitionVersion(getCoreDefinitionVersionRequest);
-
-        return Optional.ofNullable(coreDefinitionVersionResponse.definition())
-                .map(CoreDefinitionVersion::cores)
-                .filter(list -> list.size() != 0)
-                .map(list -> list.get(0))
-                .map(Core::certificateArn);
-    }
-
-    @Override
-    public GroupVersion getLatestGroupVersion(GroupInformation groupInformation) {
-        GetGroupVersionResponse groupVersionResponse = getGroupVersionResponse(groupInformation);
-
-        return groupVersionResponse.definition();
-    }
-
-    @Override
-    public String getGroupId(GroupInformation groupInformation) {
-        GetGroupVersionResponse groupVersionResponse = getGroupVersionResponse(groupInformation);
-
-        return groupVersionResponse.id();
-    }
-
-    private GetGroupVersionResponse getGroupVersionResponse(GroupInformation groupInformation) {
-        GetGroupVersionRequest getGroupVersionRequest = GetGroupVersionRequest.builder()
-                .groupId(groupInformation.id())
-                .groupVersionId(groupInformation.latestVersion())
-                .build();
-
-        return greengrassClient.getGroupVersion(getGroupVersionRequest);
-    }
-
-    @Override
-    public List<Function> getFunctions(GroupInformation groupInformation) {
-        FunctionDefinitionVersion functionDefinition = getFunctionDefinitionVersion(groupInformation);
-
-        // The returned list is an unmodifiable list, copy it to an array list so callers can modify it
-        List<Function> functions = new ArrayList<>(functionDefinition.functions());
-
-        return functions;
-    }
-
-    @Override
-    public FunctionIsolationMode getDefaultIsolationMode(GroupInformation groupInformation) {
-        FunctionDefinitionVersion functionDefinition = getFunctionDefinitionVersion(groupInformation);
-
-        Optional<FunctionIsolationMode> optionalFunctionIsolationMode = Optional.ofNullable(functionDefinition.defaultConfig())
-                .map(FunctionDefaultConfig::execution)
-                .map(FunctionDefaultExecutionConfig::isolationMode);
-
-        if (!optionalFunctionIsolationMode.isPresent()) {
-            log.warn("Default function isolation mode was not present, defaulting to Greengrass container");
-            return FunctionIsolationMode.GREENGRASS_CONTAINER;
-        }
-
-        return optionalFunctionIsolationMode.get();
-    }
-
-    @Override
-    public FunctionDefinitionVersion getFunctionDefinitionVersion(GroupInformation groupInformation) {
-        GroupVersion groupVersion = getLatestGroupVersion(groupInformation);
-
-        String functionDefinitionVersionArn = groupVersion.functionDefinitionVersionArn();
-
-        GetFunctionDefinitionVersionRequest getFunctionDefinitionVersionRequest = GetFunctionDefinitionVersionRequest.builder()
-                .functionDefinitionId(idExtractor.extractId(functionDefinitionVersionArn))
-                .functionDefinitionVersionId(idExtractor.extractVersionId(functionDefinitionVersionArn))
-                .build();
-
-        GetFunctionDefinitionVersionResponse getFunctionDefinitionVersionResponse = greengrassClient.getFunctionDefinitionVersion(getFunctionDefinitionVersionRequest);
-
-        return getFunctionDefinitionVersionResponse.definition();
-    }
-
-    @Override
-    public List<Device> getDevices(GroupInformation groupInformation) {
-        GroupVersion groupVersion = getLatestGroupVersion(groupInformation);
-
-        String deviceDefinitionVersionArn = groupVersion.deviceDefinitionVersionArn();
-
-        GetDeviceDefinitionVersionRequest getDeviceDefinitionVersionRequest = GetDeviceDefinitionVersionRequest.builder()
-                .deviceDefinitionId(idExtractor.extractId(deviceDefinitionVersionArn))
-                .deviceDefinitionVersionId(idExtractor.extractVersionId(deviceDefinitionVersionArn))
-                .build();
-
-        GetDeviceDefinitionVersionResponse getDeviceDefinitionVersionResponse = greengrassClient.getDeviceDefinitionVersion(getDeviceDefinitionVersionRequest);
-
-        DeviceDefinitionVersion deviceDefinition = getDeviceDefinitionVersionResponse.definition();
-
-        // The returned list is an unmodifiable list, copy it to an array list so callers can modify it
-        List<Device> devices = new ArrayList<>(deviceDefinition.devices());
-
-        return devices;
-    }
-
-    @Override
-    public List<Subscription> getSubscriptions(GroupInformation groupInformation) {
-        GroupVersion groupVersion = getLatestGroupVersion(groupInformation);
-
-        String subscriptionDefinitionVersionArn = groupVersion.subscriptionDefinitionVersionArn();
-
-        GetSubscriptionDefinitionVersionRequest getSubscriptionDefinitionVersionRequest = GetSubscriptionDefinitionVersionRequest.builder()
-                .subscriptionDefinitionId(idExtractor.extractId(subscriptionDefinitionVersionArn))
-                .subscriptionDefinitionVersionId(idExtractor.extractVersionId(subscriptionDefinitionVersionArn))
-                .build();
-
-        GetSubscriptionDefinitionVersionResponse getSubscriptionDefinitionVersionResponse = greengrassClient.getSubscriptionDefinitionVersion(getSubscriptionDefinitionVersionRequest);
-
-        SubscriptionDefinitionVersion subscriptionDefinition = getSubscriptionDefinitionVersionResponse.definition();
-
-        // The returned list is an unmodifiable list, copy it to an array list so callers can modify it
-        List<Subscription> subscriptions = new ArrayList<>(subscriptionDefinition.subscriptions());
-
-        return subscriptions;
-    }
-
-    @Override
-    public GetGroupCertificateAuthorityResponse getGroupCa(GroupInformation groupInformation) {
-        ListGroupCertificateAuthoritiesRequest listGroupCertificateAuthoritiesRequest = ListGroupCertificateAuthoritiesRequest.builder()
-                .groupId(groupInformation.id())
-                .build();
-
-        ListGroupCertificateAuthoritiesResponse listGroupCertificateAuthoritiesResponse = greengrassClient.listGroupCertificateAuthorities(listGroupCertificateAuthoritiesRequest);
-
-        if (listGroupCertificateAuthoritiesResponse.groupCertificateAuthorities().size() != 1) {
-            log.error("Currently we do not support multiple group CAs");
-            return null;
-        }
-
-        GetGroupCertificateAuthorityRequest getGroupCertificateAuthorityRequest = GetGroupCertificateAuthorityRequest.builder()
-                .groupId(groupInformation.id())
-                .certificateAuthorityId(listGroupCertificateAuthoritiesResponse.groupCertificateAuthorities().get(0).groupCertificateAuthorityId())
-                .build();
-
-        GetGroupCertificateAuthorityResponse getGroupCertificateAuthorityResponse = greengrassClient.getGroupCertificateAuthority(getGroupCertificateAuthorityRequest);
-
-        return getGroupCertificateAuthorityResponse;
-    }
-
-    @Override
     public Optional<String> createConnectorDefinitionVersion(List<ConnectorConf> connectorConfList) {
         if (connectorConfList.isEmpty()) {
             return Optional.empty();
@@ -1183,5 +932,17 @@ public class BasicGreengrassHelper implements GreengrassHelper {
         CreateConnectorDefinitionResponse createConnectorDefinitionResponse = greengrassClient.createConnectorDefinition(createConnectorDefinitionRequest);
 
         return Optional.of(createConnectorDefinitionResponse.latestVersionArn());
+    }
+
+    @Override
+    public FunctionIsolationMode getDefaultIsolationMode(GroupInformation groupInformation) {
+        Optional<FunctionIsolationMode> optionalFunctionIsolationMode = v2GreengrassHelper.getDefaultIsolationModeByGroupInformation(groupInformation);
+
+        if (optionalFunctionIsolationMode.isPresent()) {
+            return optionalFunctionIsolationMode.get();
+        }
+
+        log.warn("Default function isolation mode was not present, defaulting to Greengrass container");
+        return FunctionIsolationMode.GREENGRASS_CONTAINER;
     }
 }

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGroupTestHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGroupTestHelper.java
@@ -6,6 +6,7 @@ import com.awslabs.aws.greengrass.provisioner.data.arguments.TestArguments;
 import com.awslabs.aws.greengrass.provisioner.interfaces.helpers.*;
 import com.awslabs.general.helpers.interfaces.JsonHelper;
 import com.awslabs.iam.helpers.interfaces.V2IamHelper;
+import com.awslabs.iot.helpers.interfaces.V2GreengrassHelper;
 import com.jcraft.jsch.Session;
 import io.vavr.collection.HashMap;
 import io.vavr.collection.List;
@@ -50,6 +51,8 @@ public class BasicGroupTestHelper implements GroupTestHelper {
     private final Logger log = LoggerFactory.getLogger(BasicGroupTestHelper.class);
     @Inject
     GreengrassHelper greengrassHelper;
+    @Inject
+    V2GreengrassHelper v2GreengrassHelper;
     @Inject
     IotHelper iotHelper;
     @Inject
@@ -96,7 +99,7 @@ public class BasicGroupTestHelper implements GroupTestHelper {
 
         String urlForDeviceTester = optionalUrlForDeviceTester.get();
 
-        Optional<GroupInformation> optionalGroupInformation = greengrassHelper.getGroupInformation(testArguments.groupName);
+        Optional<GroupInformation> optionalGroupInformation = v2GreengrassHelper.getGroupInformationByName(testArguments.groupName).findFirst();
 
         if (!optionalGroupInformation.isPresent()) {
             throw new RuntimeException("Group [" + testArguments.groupName + "] not found");
@@ -522,7 +525,8 @@ public class BasicGroupTestHelper implements GroupTestHelper {
     }
 
     private String generateCoreAndGroupInfoJson(GroupInformation groupInformation) {
-        String groupId = greengrassHelper.getGroupId(groupInformation);
+        String groupId = v2GreengrassHelper.getGroupIdByGroupInformation(groupInformation)
+                .orElseThrow(() -> new RuntimeException("Group not found, can not continue"));
         String coreThingName = ggVariables.getCoreThingName(groupInformation.name());
 
         Map<String, String> coreInfo = HashMap.of("ThingArn", iotHelper.getThingArn(coreThingName))

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/interfaces/helpers/GreengrassHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/interfaces/helpers/GreengrassHelper.java
@@ -15,11 +15,7 @@ import java.util.Set;
 public interface GreengrassHelper {
     void associateServiceRoleToAccount(Role role);
 
-    Optional<GroupInformation> getGroupInformation(String groupNameOrGroupId);
-
     String createGroupIfNecessary(String groupName);
-
-    boolean groupExists(String groupName);
 
     void associateRoleToGroup(String groupId, Role greengrassRole);
 
@@ -70,25 +66,7 @@ public interface GreengrassHelper {
 
     void disassociateRoleFromGroup(String groupId);
 
-    Optional<GroupVersion> getLatestGroupVersion(String groupId);
-
-    Optional<String> getCoreCertificateArn(String groupId);
-
-    GroupVersion getLatestGroupVersion(GroupInformation groupInformation);
-
-    String getGroupId(GroupInformation groupInformation);
-
-    List<Function> getFunctions(GroupInformation groupInformation);
+    Optional<String> createConnectorDefinitionVersion(List<ConnectorConf> connectors);
 
     FunctionIsolationMode getDefaultIsolationMode(GroupInformation groupInformation);
-
-    FunctionDefinitionVersion getFunctionDefinitionVersion(GroupInformation groupInformation);
-
-    List<Device> getDevices(GroupInformation groupInformation);
-
-    List<Subscription> getSubscriptions(GroupInformation groupInformation);
-
-    GetGroupCertificateAuthorityResponse getGroupCa(GroupInformation groupInformation);
-
-    Optional<String> createConnectorDefinitionVersion(List<ConnectorConf> connectors);
 }

--- a/testing/integration-test.sh
+++ b/testing/integration-test.sh
@@ -14,5 +14,5 @@ find ../aws-greengrass-lambda-functions/functions -name "venv" -exec rm -rf {} \
 ./testing/push-to-dockerhub.sh
 
 rm -rf build out credentials
-./gradlew clean build integrationTest $@
+./gradlew clean build integrationTest $@ --info
 rm -rf out credentials


### PR DESCRIPTION
Pulled a lot of logic out of GGP and into the results iterator library to reduce the amount of code in GGP and to make convenience functions available to other projects.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
