### PR TITLE
Moved Debian/Raspbian/Ubuntu installations to OpenJDK JRE 11 due to OpenJDK JRE 8 instabilities

### DIFF
--- a/src/main/resources/shell/update-dependencies.sh.in
+++ b/src/main/resources/shell/update-dependencies.sh.in
@@ -46,7 +46,7 @@ else
   INSTALLER=apt-get
   # Avoid preinst and postinst tasks from asking questions
   export DEBIAN_FRONTEND=noninteractive
-  INSTALLER_SPECIFIC_PACKAGES="openjdk-8-jre-headless libsm6 iproute2"
+  INSTALLER_SPECIFIC_PACKAGES="openjdk-11-jre-headless libsm6 iproute2"
 fi
 
 UNAME=$(uname -a)


### PR DESCRIPTION
Some Greengrass Lambda functions that are in development, in particular the LLRP functions, cause OpenJDK's JRE 8 to crash. This update uses OpenJDK's JRE 11, which doesn't crash, and symlinks it to java8 so Greengrass can use it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
