### PR TITLE
Cleaned up credential output code, also creating iotcp.properties for results iterator library for each deployment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ def awsIotCoreWebsocketsVersion = '0.6.3'
 def awaitilityVersion = '4.0.2'
 def immutablesValueVersion = '2.8.3'
 def awsLambdaJavaCoreVersion = '1.2.0'
-def resultsIteratorForAwsJavaSdkVersion = '0.9.6'
+def resultsIteratorForAwsJavaSdkVersion = '0.9.8'
 def nomenEstOmenVersion = '2.0.0'
 def jschVersion = '0.1.55'
 

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGGVariables.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGGVariables.java
@@ -19,7 +19,7 @@ public class BasicGGVariables implements GGVariables {
     }
 
     @Override
-    public ThingName getCoreThingName(GreengrassGroupName greengrassGroupName) {
+    public ImmutableThingName getCoreThingName(GreengrassGroupName greengrassGroupName) {
         return ImmutableThingName.builder().name(String.join("_", greengrassGroupName.getGroupName(), "Core")).build();
     }
 

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGroupUpdateHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicGroupUpdateHelper.java
@@ -172,7 +172,7 @@ public class BasicGroupUpdateHelper implements GroupUpdateHelper {
             thingName = ImmutableThingName.builder().name(addDeviceString).build();
             log.info("No thing ARN specified for device [" + thingName.getName() + "], will re-use keys if possible");
 
-            KeysAndCertificate deviceKeysAndCertificate = iotHelper.createKeysAndCertificate(greengrassGroupId, thingName.getName());
+            KeysAndCertificate deviceKeysAndCertificate = iotHelper.createKeysAndCertificate(greengrassGroupName, thingName.getName());
 
             ImmutablePolicyName ggdPolicyName = ImmutablePolicyName.builder().name(String.join("_", thingName.getName(), "Policy")).build();
             CertificateArn certificateArn = deviceKeysAndCertificate.getCertificateArn();

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicIotHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicIotHelper.java
@@ -1,14 +1,15 @@
 package com.awslabs.aws.greengrass.provisioner.implementations.helpers;
 
 import com.awslabs.aws.greengrass.provisioner.data.KeysAndCertificate;
-import com.awslabs.aws.greengrass.provisioner.interfaces.helpers.DeploymentHelper;
 import com.awslabs.aws.greengrass.provisioner.interfaces.helpers.GGConstants;
 import com.awslabs.aws.greengrass.provisioner.interfaces.helpers.IoHelper;
 import com.awslabs.aws.greengrass.provisioner.interfaces.helpers.IotHelper;
 import com.awslabs.general.helpers.interfaces.JsonHelper;
-import com.awslabs.iot.data.GreengrassGroupId;
-import com.awslabs.iot.data.ImmutableThingName;
+import com.awslabs.iot.data.GreengrassGroupName;
+import com.awslabs.iot.data.RoleAlias;
+import com.awslabs.iot.data.ThingName;
 import com.awslabs.iot.helpers.interfaces.V2IotHelper;
+import io.vavr.control.Try;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,75 +18,80 @@ import software.amazon.awssdk.services.iot.model.CreateKeysAndCertificateRequest
 import software.amazon.awssdk.services.iot.model.CreateKeysAndCertificateResponse;
 
 import javax.inject.Inject;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.util.Optional;
+import java.util.Properties;
+
+import static com.awslabs.resultsiterator.v2.interfaces.V2CertificateCredentialsProvider.*;
 
 public class BasicIotHelper implements IotHelper {
-    private static final String BUILD_DIRECTORY = "build/";
+    private static final String CORE_DEVICE_NAME = "core";
     private static final String PEM = "pem";
     private static final String KEY = "key";
-    private static final String CRT = "crt";
     private static final String DOT_DELIMITER = ".";
-    private static final String CREDENTIALS = "credentials/";
+    private static final String CREDENTIALS_DIRECTORY_PREFIX = "credentials";
     private final Logger log = LoggerFactory.getLogger(BasicIotHelper.class);
     @Inject
     IotClient iotClient;
     @Inject
     IoHelper ioHelper;
     @Inject
-    GGConstants ggConstants;
-    @Inject
     JsonHelper jsonHelper;
     @Inject
     V2IotHelper v2IotHelper;
+    @Inject
+    GGConstants ggConstants;
 
     @Inject
     public BasicIotHelper() {
     }
 
-    private String credentialDirectoryForGroupId(GreengrassGroupId greengrassGroupId) {
-        return CREDENTIALS + greengrassGroupId.getGroupId();
-    }
-
-    private String createKeysandCertificateFilenameForGroupId(GreengrassGroupId greengrassGroupId, String subName) {
-        return credentialDirectoryForGroupId(greengrassGroupId) + "/" + subName + ".createKeysAndCertificate.serialized";
+    private String getCredentialsDirectoryForGroupName(GreengrassGroupName greengrassGroupName) {
+        return String.join("/", CREDENTIALS_DIRECTORY_PREFIX, greengrassGroupName.getGroupName());
     }
 
     @Override
-    public Optional<KeysAndCertificate> loadKeysAndCertificate(GreengrassGroupId greengrassGroupId, String subName) {
-        String credentialsDirectory = credentialDirectoryForGroupId(greengrassGroupId);
+    public Optional<KeysAndCertificate> loadKeysAndCertificateForCore(GreengrassGroupName greengrassGroupName) {
+        return loadKeysAndCertificate(greengrassGroupName, CORE_DEVICE_NAME);
+    }
 
-        ioHelper.createDirectoryIfNecessary(credentialsDirectory);
+    @Override
+    public Optional<KeysAndCertificate> loadKeysAndCertificate(GreengrassGroupName greengrassGroupName, String deviceName) {
+        ioHelper.createDirectoryIfNecessary(getCredentialsDirectoryForGroupName(greengrassGroupName));
 
-        String createKeysAndCertificateFilename = createKeysandCertificateFilenameForGroupId(greengrassGroupId, subName);
+        String createKeysAndCertificateFilename = getCreateKeysAndCertificateFilenameForGroupName(greengrassGroupName, deviceName);
 
-        if (ioHelper.exists(createKeysAndCertificateFilename)) {
-            log.info("- Attempting to reuse existing keys.");
-
-            KeysAndCertificate keysAndCertificate = jsonHelper.fromJson(KeysAndCertificate.class, ioHelper.readFile(createKeysAndCertificateFilename));
-
-            if (v2IotHelper.certificateExists(keysAndCertificate.getCertificateId())) {
-                log.info("- Reusing existing keys.");
-                return Optional.of(keysAndCertificate);
-            }
-
-            log.warn("- Existing certificate is not in AWS IoT.  It may have been deleted.");
+        if (!ioHelper.exists(createKeysAndCertificateFilename)) {
+            log.warn("- No existing keys found for group.");
             return Optional.empty();
         }
 
-        log.warn("- No existing keys found for group.");
+        log.info("- Attempting to reuse existing keys.");
+
+        KeysAndCertificate keysAndCertificate = jsonHelper.fromJson(KeysAndCertificate.class, ioHelper.readFile(createKeysAndCertificateFilename));
+
+        if (v2IotHelper.certificateExists(keysAndCertificate.getCertificateId())) {
+            log.info("- Reusing existing keys.");
+            return Optional.of(keysAndCertificate);
+        }
+
+        log.warn("- Existing certificate is not in AWS IoT.  It may have been deleted.");
         return Optional.empty();
     }
 
     @Override
-    public KeysAndCertificate createKeysAndCertificate(GreengrassGroupId greengrassGroupId, String subName) {
-        String credentialsDirectory = credentialDirectoryForGroupId(greengrassGroupId);
+    public KeysAndCertificate createKeysAndCertificateForCore(GreengrassGroupName greengrassGroupName) {
+        return createKeysAndCertificate(greengrassGroupName, CORE_DEVICE_NAME);
+    }
 
-        ioHelper.createDirectoryIfNecessary(credentialsDirectory);
-
-        String createKeysAndCertificateFilename = createKeysandCertificateFilenameForGroupId(greengrassGroupId, subName);
+    @Override
+    public KeysAndCertificate createKeysAndCertificate(GreengrassGroupName greengrassGroupName, String deviceName) {
+        ioHelper.createDirectoryIfNecessary(getCredentialsDirectoryForGroupName(greengrassGroupName));
 
         // Let them know that they'll need to re-run the bootstrap script because the core's keys changed
-        boolean isCore = subName.equals(DeploymentHelper.CORE_SUB_NAME);
+        boolean isCore = CORE_DEVICE_NAME.equals(deviceName);
         String supplementalMessage = isCore ? "  If you have an existing deployment for this group you'll need to re-run the bootstrap script since the core certificate ARN will change." : "";
         log.info("- Creating new keys." + supplementalMessage);
         CreateKeysAndCertificateRequest createKeysAndCertificateRequest = CreateKeysAndCertificateRequest.builder()
@@ -94,28 +100,110 @@ public class BasicIotHelper implements IotHelper {
 
         CreateKeysAndCertificateResponse createKeysAndCertificateResponse = iotClient.createKeysAndCertificate(createKeysAndCertificateRequest);
 
-        String deviceName = greengrassGroupId.getGroupId();
-        String privateKeyFilename = getPrivateKeyFilename(deviceName);
-        String publicSignedCertificateFilename = getPublicSignedCertificateFilename(deviceName);
-
-        ioHelper.writeFile(privateKeyFilename, createKeysAndCertificateResponse.keyPair().privateKey().getBytes());
-        log.info("Device private key written to [" + privateKeyFilename + "]");
-        ioHelper.writeFile(publicSignedCertificateFilename, createKeysAndCertificateResponse.certificatePem().getBytes());
-        log.info("Device public signed certificate key written to [" + publicSignedCertificateFilename + "]");
-
         KeysAndCertificate keysAndCertificate = KeysAndCertificate.from(createKeysAndCertificateResponse);
-        ioHelper.writeFile(createKeysAndCertificateFilename, jsonHelper.toJson(keysAndCertificate).getBytes());
+        writeKeysAndCertificateFile(keysAndCertificate, greengrassGroupName, deviceName);
 
         return keysAndCertificate;
     }
 
-    @NotNull
-    public String getPublicSignedCertificateFilename(String deviceName) {
-        return BUILD_DIRECTORY + String.join(DOT_DELIMITER, deviceName, PEM);
+    @Override
+    public void writeKeysAndCertificateFile(KeysAndCertificate keysAndCertificate, GreengrassGroupName greengrassGroupName, String subName) {
+        String createKeysAndCertificateFilename = getCreateKeysAndCertificateFilenameForGroupName(greengrassGroupName, subName);
+        ioHelper.writeFile(createKeysAndCertificateFilename, jsonHelper.toJson(keysAndCertificate).getBytes());
+        log.info("Keys and certificate data written to [" + createKeysAndCertificateFilename + "]");
+    }
+
+    @Override
+    public void writePublicSignedCertificateFileForCore(KeysAndCertificate keysAndCertificate, GreengrassGroupName greengrassGroupName) {
+        writePublicSignedCertificateFile(keysAndCertificate, greengrassGroupName, CORE_DEVICE_NAME);
+    }
+
+    @Override
+    public void writePublicSignedCertificateFile(KeysAndCertificate keysAndCertificate, GreengrassGroupName greengrassGroupName, String deviceName) {
+        String publicSignedCertificateFilename = getPublicSignedCertificateFilename(greengrassGroupName, deviceName);
+        ioHelper.writeFile(publicSignedCertificateFilename, keysAndCertificate.getCertificatePem().getPem().getBytes());
+        log.info("Device public signed certificate key written to [" + publicSignedCertificateFilename + "]");
+    }
+
+    @Override
+    public void writePrivateKeyFileForCore(KeysAndCertificate keysAndCertificate, GreengrassGroupName greengrassGroupName) {
+        writePrivateKeyFile(keysAndCertificate, greengrassGroupName, CORE_DEVICE_NAME);
+    }
+
+    @Override
+    public void writePrivateKeyFile(KeysAndCertificate keysAndCertificate, GreengrassGroupName greengrassGroupName, String deviceName) {
+        String privateKeyFilename = getPrivateKeyFilename(greengrassGroupName, deviceName);
+        ioHelper.writeFile(privateKeyFilename, keysAndCertificate.getKeyPair().privateKey().getBytes());
+        log.info("Device private key written to [" + privateKeyFilename + "]");
+    }
+
+    @Override
+    public void writeRootCaFile(GreengrassGroupName greengrassGroupName) {
+        String rootCaFilename = getRootCaFilename(greengrassGroupName);
+        ioHelper.writeFile(rootCaFilename, ioHelper.download(ggConstants.getRootCaUrl()).getBytes());
+        log.info("Root CA certificate written to [" + rootCaFilename + "]");
+    }
+
+    @Override
+    public void writeIotCpPropertiesFile(GreengrassGroupName greengrassGroupName, ThingName coreThingName, RoleAlias coreRoleAlias) {
+        Properties properties = new Properties();
+
+        properties.setProperty(AWS_CREDENTIAL_PROVIDER_URL, v2IotHelper.getCredentialProviderUrl());
+        properties.setProperty(AWS_THING_NAME, coreThingName.getName());
+        properties.setProperty(AWS_ROLE_ALIAS, coreRoleAlias.getName());
+        properties.setProperty(AWS_CA_CERT_FILENAME, toRelativePath(getRootCaFilename(greengrassGroupName)));
+        properties.setProperty(AWS_CLIENT_CERT_FILENAME, toRelativePath(getPublicSignedCertificateFilenameForCore(greengrassGroupName)));
+        properties.setProperty(AWS_CLIENT_PRIVATE_KEY_FILENAME, toRelativePath(getPrivateKeyFilenameForCore(greengrassGroupName)));
+
+        Try.withResources(() -> new FileOutputStream(getIotCpPropertiesFilename(greengrassGroupName)))
+                .of(fileOutputStream -> storeProperties(fileOutputStream, properties))
+                .get();
+
+        log.info("IoT Credentials Provider properties written to [" + getIotCpPropertiesFilename(greengrassGroupName) + "]");
+    }
+
+    private String toRelativePath(String filename) {
+        return new File(filename).getName();
+    }
+
+    private Void storeProperties(FileOutputStream fileOutputStream, Properties properties) throws IOException {
+        properties.store(fileOutputStream, null);
+
+        return null;
     }
 
     @NotNull
-    public String getPrivateKeyFilename(String deviceName) {
-        return BUILD_DIRECTORY + String.join(DOT_DELIMITER, deviceName, KEY);
+    private String getCreateKeysAndCertificateFilenameForGroupName(GreengrassGroupName greengrassGroupName, String deviceName) {
+        return String.join("/", getCredentialsDirectoryForGroupName(greengrassGroupName), String.join(".", deviceName, "createKeysAndCertificate.serialized"));
+    }
+
+    @NotNull
+    private String getPublicSignedCertificateFilenameForCore(GreengrassGroupName greengrassGroupName) {
+        return getPublicSignedCertificateFilename(greengrassGroupName, CORE_DEVICE_NAME);
+    }
+
+    @NotNull
+    private String getPublicSignedCertificateFilename(GreengrassGroupName greengrassGroupName, String deviceName) {
+        return String.join("/", getCredentialsDirectoryForGroupName(greengrassGroupName), String.join(DOT_DELIMITER, deviceName, PEM));
+    }
+
+    @NotNull
+    private String getRootCaFilename(GreengrassGroupName greengrassGroupName) {
+        return String.join("/", getCredentialsDirectoryForGroupName(greengrassGroupName), String.join(DOT_DELIMITER, "root", "ca", PEM));
+    }
+
+    @NotNull
+    private String getPrivateKeyFilenameForCore(GreengrassGroupName greengrassGroupName) {
+        return getPrivateKeyFilename(greengrassGroupName, CORE_DEVICE_NAME);
+    }
+
+    @NotNull
+    private String getPrivateKeyFilename(GreengrassGroupName greengrassGroupName, String deviceName) {
+        return String.join("/", getCredentialsDirectoryForGroupName(greengrassGroupName), String.join(DOT_DELIMITER, deviceName, KEY));
+    }
+
+    @NotNull
+    private String getIotCpPropertiesFilename(GreengrassGroupName greengrassGroupName) {
+        return String.join("/", getCredentialsDirectoryForGroupName(greengrassGroupName), String.join(DOT_DELIMITER, "iotcp", "properties"));
     }
 }

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/interfaces/helpers/DeploymentHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/interfaces/helpers/DeploymentHelper.java
@@ -11,7 +11,6 @@ import java.util.Optional;
 
 public interface DeploymentHelper extends Operation<DeploymentArguments> {
     String EMPTY = "EMPTY";
-    String CORE_SUB_NAME = "core";
 
     DeploymentConf getDeploymentConf(ThingName coreThingName, String deploymentConfigFilename, GreengrassGroupName greengrassGroupName);
 

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/interfaces/helpers/GGVariables.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/interfaces/helpers/GGVariables.java
@@ -1,6 +1,7 @@
 package com.awslabs.aws.greengrass.provisioner.interfaces.helpers;
 
 import com.awslabs.iot.data.GreengrassGroupName;
+import com.awslabs.iot.data.ImmutableThingName;
 import com.awslabs.iot.data.PolicyName;
 import com.awslabs.iot.data.ThingName;
 import com.typesafe.config.Config;
@@ -8,7 +9,7 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.greengrass.model.FunctionIsolationMode;
 
 public interface GGVariables {
-    ThingName getCoreThingName(GreengrassGroupName greengrassGroupName);
+    ImmutableThingName getCoreThingName(GreengrassGroupName greengrassGroupName);
 
     String getCoreDefinitionName(GreengrassGroupName greengrassGroupName);
 

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/interfaces/helpers/IotHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/interfaces/helpers/IotHelper.java
@@ -1,12 +1,30 @@
 package com.awslabs.aws.greengrass.provisioner.interfaces.helpers;
 
 import com.awslabs.aws.greengrass.provisioner.data.KeysAndCertificate;
-import com.awslabs.iot.data.GreengrassGroupId;
+import com.awslabs.iot.data.*;
 
 import java.util.Optional;
 
 public interface IotHelper {
-    Optional<KeysAndCertificate> loadKeysAndCertificate(GreengrassGroupId greengrassGroupId, String subName);
+    Optional<KeysAndCertificate> loadKeysAndCertificateForCore(GreengrassGroupName greengrassGroupName);
 
-    KeysAndCertificate createKeysAndCertificate(GreengrassGroupId greengrassGroupId, String subName);
+    Optional<KeysAndCertificate> loadKeysAndCertificate(GreengrassGroupName greengrassGroupName, String deviceName);
+
+    KeysAndCertificate createKeysAndCertificateForCore(GreengrassGroupName greengrassGroupName);
+
+    KeysAndCertificate createKeysAndCertificate(GreengrassGroupName greengrassGroupName, String deviceName);
+
+    void writeKeysAndCertificateFile(KeysAndCertificate keysAndCertificate, GreengrassGroupName greengrassGroupName, String deviceName);
+
+    void writePublicSignedCertificateFileForCore(KeysAndCertificate keysAndCertificate, GreengrassGroupName greengrassGroupName);
+
+    void writePublicSignedCertificateFile(KeysAndCertificate keysAndCertificate, GreengrassGroupName greengrassGroupName, String deviceName);
+
+    void writePrivateKeyFileForCore(KeysAndCertificate keysAndCertificate, GreengrassGroupName greengrassGroupName);
+
+    void writePrivateKeyFile(KeysAndCertificate keysAndCertificate, GreengrassGroupName greengrassGroupName, String deviceName);
+
+    void writeRootCaFile(GreengrassGroupName greengrassGroupName);
+
+    void writeIotCpPropertiesFile(GreengrassGroupName greengrassGroupName, ThingName coreThingName, RoleAlias coreRoleAlias);
 }


### PR DESCRIPTION
Integration tests already passed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
