### PR TITLE
Add Region Support for Provisioner Lambda

### DIFF
--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/lambda/AwsGreengrassProvisionerLambda.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/lambda/AwsGreengrassProvisionerLambda.java
@@ -86,6 +86,13 @@ public class AwsGreengrassProvisionerLambda implements RequestHandler<LambdaInpu
         System.setProperty("aws.accessKeyId", lambdaInput.AccessKeyId);
         System.setProperty("aws.secretAccessKey", lambdaInput.SecretAccessKey);
         System.setProperty("aws.sessionToken", lambdaInput.SessionToken);
+
+        if (lambdaInput.Region == null) {
+            return;
+        }
+        else {
+            System.setProperty("aws.region", lambdaInput.Region);
+        }
     }
 
     private void addCsrOption(List<String> args, String csr) {

--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/lambda/LambdaInput.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/lambda/LambdaInput.java
@@ -4,6 +4,7 @@ public class LambdaInput {
     public String AccessKeyId;
     public String SecretAccessKey;
     public String SessionToken;
+    public String Region;
     public String Csr;
     public String CertificateArn;
     public boolean ServiceRoleExists;


### PR DESCRIPTION
Add the ability to specify region along
with AWS Creds so that the IoT resources
are created in the appropriate AWS region.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
