### PR TITLE
Add commandline for installing python3-devel.x86_64 in Dockerfile.run

### DIFF
--- a/Dockerfile.run
+++ b/Dockerfile.run
@@ -21,6 +21,7 @@ RUN yum install -y python2-pip python2 python2-setuptools && \
 
 # Install pip so Python 3 functions can be built
 RUN yum install -y python3-pip python3 python3-setuptools && \
+    yum install -y python3-devel.x86_64 && \
     yum clean all && rm -rf /var/cache/yum
 
 # Install NodeJS and npm so Node functions can be built


### PR DESCRIPTION
Fixes: #811 

*Description of changes:*
Add a commandline for installing python3-devel.x86_64 in Dockerfile.run

Installing some python packages need to be installed `python3-devel.x86_64` in the machine.

So I add `yum install -y python3-devel.x86_64` in `Dockerfile.run`