### PR TITLE
Using a failsafe executor to deal with Lambda API paths that can return that a function is in the pending state

### DIFF
--- a/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicLambdaHelper.java
+++ b/src/main/java/com/awslabs/aws/greengrass/provisioner/implementations/helpers/BasicLambdaHelper.java
@@ -216,11 +216,11 @@ public class BasicLambdaHelper implements LambdaHelper {
         if (v2LambdaHelper.functionExists(functionConf.getGroupFunctionName())) {
             // Update the function
             //   NOTE: Sometimes the Lambda IAM role isn't immediately visible so we need retries
-            return Either.right(updateExistingLambdaFunction(functionConf, role, functionConf.getFunctionName(), functionConf.getGroupFunctionName(), functionCode, runtime, lambdaFailsafeExecutor));
+            return Either.right(updateExistingLambdaFunction(functionConf, role, functionConf.getFunctionName(), functionConf.getGroupFunctionName(), functionCode, runtime));
         }
 
         // Create a new function
-        return Either.left(createNewLambdaFunction(functionConf, role, functionConf.getFunctionName(), functionConf.getGroupFunctionName(), functionCode, runtime, lambdaFailsafeExecutor));
+        return Either.left(createNewLambdaFunction(functionConf, role, functionConf.getFunctionName(), functionConf.getGroupFunctionName(), functionCode, runtime));
     }
 
     @Override
@@ -238,7 +238,7 @@ public class BasicLambdaHelper implements LambdaHelper {
                 .build();
     }
 
-    private UpdateFunctionConfigurationResponse updateExistingLambdaFunction(FunctionConf functionConf, Role role, FunctionName baseFunctionName, FunctionName functionName, FunctionCode functionCode, String runtime, FailsafeExecutor<LambdaResponse> lambdaFailsafeExecutor) {
+    private UpdateFunctionConfigurationResponse updateExistingLambdaFunction(FunctionConf functionConf, Role role, FunctionName baseFunctionName, FunctionName functionName, FunctionCode functionCode, String runtime) {
         loggingHelper.logInfoWithName(log, baseFunctionName.getName(), "Updating Lambda function code");
 
         UpdateFunctionCodeRequest.Builder updateFunctionCodeRequestBuilder = UpdateFunctionCodeRequest.builder()
@@ -292,7 +292,7 @@ public class BasicLambdaHelper implements LambdaHelper {
         return newEnvironment;
     }
 
-    private CreateFunctionResponse createNewLambdaFunction(FunctionConf functionConf, Role role, FunctionName baseFunctionName, FunctionName functionName, FunctionCode functionCode, String runtime, FailsafeExecutor<LambdaResponse> lambdaFailsafeExecutor) {
+    private CreateFunctionResponse createNewLambdaFunction(FunctionConf functionConf, Role role, FunctionName baseFunctionName, FunctionName functionName, FunctionCode functionCode, String runtime) {
         loggingHelper.logInfoWithName(log, baseFunctionName.getName(), "Creating new Lambda function");
 
         // No environment, start with an empty one


### PR DESCRIPTION
Lambda functions can now report that they are in a pending state. The existing logic didn't handle this.

This was reported in #970 but initial testing of the fix wasn't successful.

After further research it appears that #970 addresses the pending state issue when an existing function is updated but not when a new function is created.

The solution was to modify the LambdaClient calls to updateFunctionCode, createFunction, and updateFunctionConfiguration by wrapping them in a failsafe executor that handles IAM propagation delays as well as the Lambda pending function state.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
